### PR TITLE
Improve mobile nav behavior, drag-and-drop UX, font loading and stylesheet bump to v1.0.8

### DIFF
--- a/bloodborne.html
+++ b/bloodborne.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -18,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Bloodborne - Fashion Souls v1.0.8</title>
+    <title>Bloodborne - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -185,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.8"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "bloodborne_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");

--- a/bloodborne.html
+++ b/bloodborne.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Up your Hunter's style with souls.fashion, the tool for finding color-matching attire and weapons in Bloodborne. Create a striking look as you explore Yharnam and face the nightmarish beasts in fashion.">
 		<meta property="og:site_name" content="Bloodborne - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -180,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.8"></script>
     <script>
 	const gamePrefix = "bloodborne_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -188,64 +193,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -325,35 +317,10 @@
       });
 
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
-        }
-      });
+      function updateScrollUI() {
+        const scrollY = window.scrollY || window.pageYOffset || 0;
 
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-        }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
-
-      window.addEventListener("scroll", () => {
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +329,35 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -579,6 +557,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +571,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +606,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +651,7 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
     });
 
 };
@@ -678,8 +672,6 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
     });
 });
-
-window.onresize = adjustPinnedStyles;
 
 
   </script>

--- a/bloodborne.html
+++ b/bloodborne.html
@@ -91,7 +91,12 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
+        <div class="tile-size-control">
+          <label for="tileSizeSlider">Tile Size</label>
+          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
+          <p id="tileSizeValue">100%</p>
+        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -316,9 +321,35 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      function initTileSizeControl() {
+        const tileSizeSlider = document.getElementById("tileSizeSlider");
+        const tileSizeValue = document.getElementById("tileSizeValue");
+        if (!tileSizeSlider || !tileSizeValue) {
+          return;
+        }
+
+        const key = `${gamePrefix}tileSizeScale`;
+        const savedValue = Number(localStorage.getItem(key)) || 100;
+        const clampedValue = Math.min(130, Math.max(80, savedValue));
+
+        const applyScale = (value) => {
+          const scale = value / 100;
+          document.documentElement.style.setProperty("--item-card-scale", String(scale));
+          tileSizeValue.textContent = `${value}%`;
+          localStorage.setItem(key, String(value));
+        };
+
+        tileSizeSlider.value = String(clampedValue);
+        applyScale(clampedValue);
+
+        tileSizeSlider.addEventListener("input", (event) => {
+          applyScale(Number(event.target.value));
+        });
+      }
+
 
       function updateScrollUI() {
-        const scrollY = window.scrollY || window.pageYOffset || 0;
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
 
         if (window.scrollY > 400) {
           document.querySelector(".back-to-top-button").style.opacity = "1";
@@ -332,7 +363,8 @@
 
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
-          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          const atTop = scrollY <= 4;
+          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
@@ -413,6 +445,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -652,6 +685,7 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
+        initTileSizeControl();
     });
 
 };

--- a/bloodborne.html
+++ b/bloodborne.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Up your Hunter's style with souls.fashion, the tool for finding color-matching attire and weapons in Bloodborne. Create a striking look as you explore Yharnam and face the nightmarish beasts in fashion.">
 		<meta property="og:site_name" content="Bloodborne - Fashion Souls" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -92,11 +92,6 @@
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
                 <button id="clearFilter">Clear Filters</button>
-        <div class="tile-size-control">
-          <label for="tileSizeSlider">Tile Size</label>
-          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
-          <p id="tileSizeValue">100%</p>
-        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -161,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -321,30 +322,88 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      function initTileSizeControl() {
-        const tileSizeSlider = document.getElementById("tileSizeSlider");
-        const tileSizeValue = document.getElementById("tileSizeValue");
-        if (!tileSizeSlider || !tileSizeValue) {
+      let currentGridScale = 100;
+
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
+        }
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+        }
+
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
           return;
         }
 
-        const key = `${gamePrefix}tileSizeScale`;
-        const savedValue = Number(localStorage.getItem(key)) || 100;
-        const clampedValue = Math.min(130, Math.max(80, savedValue));
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
 
-        const applyScale = (value) => {
-          const scale = value / 100;
-          document.documentElement.style.setProperty("--item-card-scale", String(scale));
-          tileSizeValue.textContent = `${value}%`;
-          localStorage.setItem(key, String(value));
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
         };
 
-        tileSizeSlider.value = String(clampedValue);
-        applyScale(clampedValue);
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
 
-        tileSizeSlider.addEventListener("input", (event) => {
-          applyScale(Number(event.target.value));
-        });
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
       }
 
 
@@ -689,7 +748,8 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
-        initTileSizeControl();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };

--- a/bloodborne.html
+++ b/bloodborne.html
@@ -364,10 +364,14 @@
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
           const atTop = scrollY <= 4;
-          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
           sidebarActive = false;
           navActive = true;
           showNav();

--- a/demonssouls.html
+++ b/demonssouls.html
@@ -3,7 +3,7 @@
   <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="description" content="Design perfect color-matching outfits in Elden Ring with souls.fashion. Explore coordinated armor sets, weapons, and accessories for a unique style that suits your Tarnished – the ultimate Elden Ring fashion tool!">
 		<meta property="og:site_name" content="Elden Ring - Fashion Souls" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -115,11 +115,6 @@
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
                 <button id="clearFilter">Clear Filters</button>
-        <div class="tile-size-control">
-          <label for="tileSizeSlider">Tile Size</label>
-          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
-          <p id="tileSizeValue">100%</p>
-        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -184,6 +179,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -345,30 +346,88 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      function initTileSizeControl() {
-        const tileSizeSlider = document.getElementById("tileSizeSlider");
-        const tileSizeValue = document.getElementById("tileSizeValue");
-        if (!tileSizeSlider || !tileSizeValue) {
+      let currentGridScale = 100;
+
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
+        }
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+        }
+
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
           return;
         }
 
-        const key = `${gamePrefix}tileSizeScale`;
-        const savedValue = Number(localStorage.getItem(key)) || 100;
-        const clampedValue = Math.min(130, Math.max(80, savedValue));
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
 
-        const applyScale = (value) => {
-          const scale = value / 100;
-          document.documentElement.style.setProperty("--item-card-scale", String(scale));
-          tileSizeValue.textContent = `${value}%`;
-          localStorage.setItem(key, String(value));
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
         };
 
-        tileSizeSlider.value = String(clampedValue);
-        applyScale(clampedValue);
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
 
-        tileSizeSlider.addEventListener("input", (event) => {
-          applyScale(Number(event.target.value));
-        });
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
       }
 
 
@@ -715,7 +774,8 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
-        initTileSizeControl();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };

--- a/demonssouls.html
+++ b/demonssouls.html
@@ -114,7 +114,12 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
+        <div class="tile-size-control">
+          <label for="tileSizeSlider">Tile Size</label>
+          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
+          <p id="tileSizeValue">100%</p>
+        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -340,9 +345,35 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      function initTileSizeControl() {
+        const tileSizeSlider = document.getElementById("tileSizeSlider");
+        const tileSizeValue = document.getElementById("tileSizeValue");
+        if (!tileSizeSlider || !tileSizeValue) {
+          return;
+        }
+
+        const key = `${gamePrefix}tileSizeScale`;
+        const savedValue = Number(localStorage.getItem(key)) || 100;
+        const clampedValue = Math.min(130, Math.max(80, savedValue));
+
+        const applyScale = (value) => {
+          const scale = value / 100;
+          document.documentElement.style.setProperty("--item-card-scale", String(scale));
+          tileSizeValue.textContent = `${value}%`;
+          localStorage.setItem(key, String(value));
+        };
+
+        tileSizeSlider.value = String(clampedValue);
+        applyScale(clampedValue);
+
+        tileSizeSlider.addEventListener("input", (event) => {
+          applyScale(Number(event.target.value));
+        });
+      }
+
 
       function updateScrollUI() {
-        const scrollY = window.scrollY || window.pageYOffset || 0;
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
 
         if (window.scrollY > 400) {
           document.querySelector(".back-to-top-button").style.opacity = "1";
@@ -356,7 +387,8 @@
 
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
-          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          const atTop = scrollY <= 4;
+          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
@@ -437,6 +469,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -678,6 +711,7 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
+        initTileSizeControl();
     });
 
 };

--- a/demonssouls.html
+++ b/demonssouls.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap" />
-    <link rel="stylesheet" href="resources/styles.css?v1.0.8" />
+    <link rel="stylesheet" href="resources/styles.css?v1.0.9" />
     <link rel="icon" type="image/x-icon" href="icon.ico" />
     <link
       rel="apple-touch-icon"
@@ -41,7 +41,7 @@
       sizes="96x96"
       href="favicons/icon_96x96.png"
     />
-    <title>Demon's Souls - Fashion Souls v1.0.8</title>
+    <title>Demon's Souls - Fashion Souls v1.0.9</title>
   </head>
   <body>
   <div id="preloader" class="preloader">
@@ -209,7 +209,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.8"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "eldenring_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");

--- a/demonssouls.html
+++ b/demonssouls.html
@@ -388,10 +388,14 @@
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
           const atTop = scrollY <= 4;
-          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
           sidebarActive = false;
           navActive = true;
           showNav();

--- a/demonssouls.html
+++ b/demonssouls.html
@@ -6,11 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta name="description" content="Design perfect color-matching outfits in Elden Ring with souls.fashion. Explore coordinated armor sets, weapons, and accessories for a unique style that suits your Tarnished – the ultimate Elden Ring fashion tool!">
 		<meta property="og:site_name" content="Elden Ring - Fashion Souls" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Spectral"
-    />
-    <link rel="stylesheet" href="resources/styles.css?v1.0.5" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap" />
+    <link rel="stylesheet" href="resources/styles.css?v1.0.8" />
     <link rel="icon" type="image/x-icon" href="icon.ico" />
     <link
       rel="apple-touch-icon"
@@ -52,7 +51,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -207,7 +209,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.8"></script>
     <script>
 	const gamePrefix = "eldenring_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -215,64 +217,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -352,35 +341,10 @@
       });
 
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
-        }
-      });
+      function updateScrollUI() {
+        const scrollY = window.scrollY || window.pageYOffset || 0;
 
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-        }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
-
-      window.addEventListener("scroll", () => {
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -389,24 +353,35 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -608,6 +583,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -617,16 +597,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -635,33 +632,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -687,6 +677,7 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
     });
 
 };
@@ -708,8 +699,6 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
-
-window.onresize = adjustPinnedStyles;
 
 
   </script>

--- a/ds1.html
+++ b/ds1.html
@@ -91,7 +91,12 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
+        <div class="tile-size-control">
+          <label for="tileSizeSlider">Tile Size</label>
+          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
+          <p id="tileSizeValue">100%</p>
+        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -316,9 +321,35 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      function initTileSizeControl() {
+        const tileSizeSlider = document.getElementById("tileSizeSlider");
+        const tileSizeValue = document.getElementById("tileSizeValue");
+        if (!tileSizeSlider || !tileSizeValue) {
+          return;
+        }
+
+        const key = `${gamePrefix}tileSizeScale`;
+        const savedValue = Number(localStorage.getItem(key)) || 100;
+        const clampedValue = Math.min(130, Math.max(80, savedValue));
+
+        const applyScale = (value) => {
+          const scale = value / 100;
+          document.documentElement.style.setProperty("--item-card-scale", String(scale));
+          tileSizeValue.textContent = `${value}%`;
+          localStorage.setItem(key, String(value));
+        };
+
+        tileSizeSlider.value = String(clampedValue);
+        applyScale(clampedValue);
+
+        tileSizeSlider.addEventListener("input", (event) => {
+          applyScale(Number(event.target.value));
+        });
+      }
+
 
       function updateScrollUI() {
-        const scrollY = window.scrollY || window.pageYOffset || 0;
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
 
         if (window.scrollY > 400) {
           document.querySelector(".back-to-top-button").style.opacity = "1";
@@ -332,7 +363,8 @@
 
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
-          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          const atTop = scrollY <= 4;
+          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
@@ -413,6 +445,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -652,6 +685,7 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
+        initTileSizeControl();
     });
 
 };

--- a/ds1.html
+++ b/ds1.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Style your Undead in Dark Souls Remastered & Prepare to Die Edition with souls.fashion, the tool for finding color-coordinated armor and weapons. Create iconic looks as you journey through Lordran with gear that stands out.">
 		<meta property="og:site_name" content="Dark Souls - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -180,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.8"></script>
    <script>
 	const gamePrefix = "ds1_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -189,63 +194,50 @@
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
       
+      const nav = document.querySelector('.navigation');
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -325,35 +317,10 @@
       });
 
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
-        }
-      });
+      function updateScrollUI() {
+        const scrollY = window.scrollY || window.pageYOffset || 0;
 
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-        }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
-
-      window.addEventListener("scroll", () => {
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +329,35 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -579,6 +557,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +571,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +606,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +651,7 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
     });
 
 };
@@ -678,9 +672,6 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
     });
 });
-
-window.onresize = adjustPinnedStyles;
-
 
   </script>
     <script>

--- a/ds1.html
+++ b/ds1.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -18,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Dark Souls - Fashion Souls v1.0.8</title>
+    <title>Dark Souls - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -185,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.8"></script>
+    <script src="search_items.js?v1.0.9"></script>
    <script>
 	const gamePrefix = "ds1_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");

--- a/ds1.html
+++ b/ds1.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Style your Undead in Dark Souls Remastered & Prepare to Die Edition with souls.fashion, the tool for finding color-coordinated armor and weapons. Create iconic looks as you journey through Lordran with gear that stands out.">
 		<meta property="og:site_name" content="Dark Souls - Fashion Souls" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -92,11 +92,6 @@
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
                 <button id="clearFilter">Clear Filters</button>
-        <div class="tile-size-control">
-          <label for="tileSizeSlider">Tile Size</label>
-          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
-          <p id="tileSizeValue">100%</p>
-        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -161,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -321,30 +322,88 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      function initTileSizeControl() {
-        const tileSizeSlider = document.getElementById("tileSizeSlider");
-        const tileSizeValue = document.getElementById("tileSizeValue");
-        if (!tileSizeSlider || !tileSizeValue) {
+      let currentGridScale = 100;
+
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
+        }
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+        }
+
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
           return;
         }
 
-        const key = `${gamePrefix}tileSizeScale`;
-        const savedValue = Number(localStorage.getItem(key)) || 100;
-        const clampedValue = Math.min(130, Math.max(80, savedValue));
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
 
-        const applyScale = (value) => {
-          const scale = value / 100;
-          document.documentElement.style.setProperty("--item-card-scale", String(scale));
-          tileSizeValue.textContent = `${value}%`;
-          localStorage.setItem(key, String(value));
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
         };
 
-        tileSizeSlider.value = String(clampedValue);
-        applyScale(clampedValue);
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
 
-        tileSizeSlider.addEventListener("input", (event) => {
-          applyScale(Number(event.target.value));
-        });
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
       }
 
 
@@ -689,7 +748,8 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
-        initTileSizeControl();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };

--- a/ds1.html
+++ b/ds1.html
@@ -364,10 +364,14 @@
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
           const atTop = scrollY <= 4;
-          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
           sidebarActive = false;
           navActive = true;
           showNav();

--- a/ds2.html
+++ b/ds2.html
@@ -91,7 +91,12 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
+        <div class="tile-size-control">
+          <label for="tileSizeSlider">Tile Size</label>
+          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
+          <p id="tileSizeValue">100%</p>
+        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -316,9 +321,35 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      function initTileSizeControl() {
+        const tileSizeSlider = document.getElementById("tileSizeSlider");
+        const tileSizeValue = document.getElementById("tileSizeValue");
+        if (!tileSizeSlider || !tileSizeValue) {
+          return;
+        }
+
+        const key = `${gamePrefix}tileSizeScale`;
+        const savedValue = Number(localStorage.getItem(key)) || 100;
+        const clampedValue = Math.min(130, Math.max(80, savedValue));
+
+        const applyScale = (value) => {
+          const scale = value / 100;
+          document.documentElement.style.setProperty("--item-card-scale", String(scale));
+          tileSizeValue.textContent = `${value}%`;
+          localStorage.setItem(key, String(value));
+        };
+
+        tileSizeSlider.value = String(clampedValue);
+        applyScale(clampedValue);
+
+        tileSizeSlider.addEventListener("input", (event) => {
+          applyScale(Number(event.target.value));
+        });
+      }
+
 
       function updateScrollUI() {
-        const scrollY = window.scrollY || window.pageYOffset || 0;
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
 
         if (window.scrollY > 400) {
           document.querySelector(".back-to-top-button").style.opacity = "1";
@@ -332,7 +363,8 @@
 
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
-          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          const atTop = scrollY <= 4;
+          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
@@ -413,6 +445,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -652,6 +685,7 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
+        initTileSizeControl();
     });
 
 };

--- a/ds2.html
+++ b/ds2.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -18,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Dark Souls II - Fashion Souls v1.0.8</title>
+    <title>Dark Souls II - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -185,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.8"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "ds2_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");

--- a/ds2.html
+++ b/ds2.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Transform your journey in Dark Souls 2 with souls.fashion, the ultimate Dark Souls II fashion tool. Find matching armor and weapons to create a distinct look for your character as you explore the kingdom of Drangleic.">
 		<meta property="og:site_name" content="Dark Souls II - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -180,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.8"></script>
     <script>
 	const gamePrefix = "ds2_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -188,64 +193,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -325,35 +317,10 @@
       });
 
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
-        }
-      });
+      function updateScrollUI() {
+        const scrollY = window.scrollY || window.pageYOffset || 0;
 
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-        }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
-
-      window.addEventListener("scroll", () => {
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +329,35 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -579,6 +557,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +571,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +606,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +651,7 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
     });
 
 };
@@ -678,8 +672,6 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
     });
 });
-
-window.onresize = adjustPinnedStyles;
 
 
   </script>

--- a/ds2.html
+++ b/ds2.html
@@ -364,10 +364,14 @@
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
           const atTop = scrollY <= 4;
-          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
           sidebarActive = false;
           navActive = true;
           showNav();

--- a/ds2.html
+++ b/ds2.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Transform your journey in Dark Souls 2 with souls.fashion, the ultimate Dark Souls II fashion tool. Find matching armor and weapons to create a distinct look for your character as you explore the kingdom of Drangleic.">
 		<meta property="og:site_name" content="Dark Souls II - Fashion Souls" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -92,11 +92,6 @@
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
                 <button id="clearFilter">Clear Filters</button>
-        <div class="tile-size-control">
-          <label for="tileSizeSlider">Tile Size</label>
-          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
-          <p id="tileSizeValue">100%</p>
-        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -161,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -321,30 +322,88 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      function initTileSizeControl() {
-        const tileSizeSlider = document.getElementById("tileSizeSlider");
-        const tileSizeValue = document.getElementById("tileSizeValue");
-        if (!tileSizeSlider || !tileSizeValue) {
+      let currentGridScale = 100;
+
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
+        }
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+        }
+
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
           return;
         }
 
-        const key = `${gamePrefix}tileSizeScale`;
-        const savedValue = Number(localStorage.getItem(key)) || 100;
-        const clampedValue = Math.min(130, Math.max(80, savedValue));
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
 
-        const applyScale = (value) => {
-          const scale = value / 100;
-          document.documentElement.style.setProperty("--item-card-scale", String(scale));
-          tileSizeValue.textContent = `${value}%`;
-          localStorage.setItem(key, String(value));
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
         };
 
-        tileSizeSlider.value = String(clampedValue);
-        applyScale(clampedValue);
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
 
-        tileSizeSlider.addEventListener("input", (event) => {
-          applyScale(Number(event.target.value));
-        });
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
       }
 
 
@@ -689,7 +748,8 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
-        initTileSizeControl();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };

--- a/ds3.html
+++ b/ds3.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -18,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Dark Souls III - Fashion Souls v1.0.8</title>
+    <title>Dark Souls III - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -185,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.8"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "ds3_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");

--- a/ds3.html
+++ b/ds3.html
@@ -91,7 +91,12 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
+        <div class="tile-size-control">
+          <label for="tileSizeSlider">Tile Size</label>
+          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
+          <p id="tileSizeValue">100%</p>
+        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -316,9 +321,35 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      function initTileSizeControl() {
+        const tileSizeSlider = document.getElementById("tileSizeSlider");
+        const tileSizeValue = document.getElementById("tileSizeValue");
+        if (!tileSizeSlider || !tileSizeValue) {
+          return;
+        }
+
+        const key = `${gamePrefix}tileSizeScale`;
+        const savedValue = Number(localStorage.getItem(key)) || 100;
+        const clampedValue = Math.min(130, Math.max(80, savedValue));
+
+        const applyScale = (value) => {
+          const scale = value / 100;
+          document.documentElement.style.setProperty("--item-card-scale", String(scale));
+          tileSizeValue.textContent = `${value}%`;
+          localStorage.setItem(key, String(value));
+        };
+
+        tileSizeSlider.value = String(clampedValue);
+        applyScale(clampedValue);
+
+        tileSizeSlider.addEventListener("input", (event) => {
+          applyScale(Number(event.target.value));
+        });
+      }
+
 
       function updateScrollUI() {
-        const scrollY = window.scrollY || window.pageYOffset || 0;
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
 
         if (window.scrollY > 400) {
           document.querySelector(".back-to-top-button").style.opacity = "1";
@@ -332,7 +363,8 @@
 
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
-          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          const atTop = scrollY <= 4;
+          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
@@ -413,6 +445,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -652,6 +685,7 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
+        initTileSizeControl();
     });
 
 };

--- a/ds3.html
+++ b/ds3.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Unleash your Ashen One’s true colors in Dark Souls 3 with souls.fashion. This tool helps you discover coordinated armor sets and weapons, creating unforgettable looks for your journey through Lothric.">
 		<meta property="og:site_name" content="Dark Souls III - Fashion Souls" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -92,11 +92,6 @@
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
                 <button id="clearFilter">Clear Filters</button>
-        <div class="tile-size-control">
-          <label for="tileSizeSlider">Tile Size</label>
-          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
-          <p id="tileSizeValue">100%</p>
-        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -161,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -321,30 +322,88 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      function initTileSizeControl() {
-        const tileSizeSlider = document.getElementById("tileSizeSlider");
-        const tileSizeValue = document.getElementById("tileSizeValue");
-        if (!tileSizeSlider || !tileSizeValue) {
+      let currentGridScale = 100;
+
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
+        }
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+        }
+
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
           return;
         }
 
-        const key = `${gamePrefix}tileSizeScale`;
-        const savedValue = Number(localStorage.getItem(key)) || 100;
-        const clampedValue = Math.min(130, Math.max(80, savedValue));
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
 
-        const applyScale = (value) => {
-          const scale = value / 100;
-          document.documentElement.style.setProperty("--item-card-scale", String(scale));
-          tileSizeValue.textContent = `${value}%`;
-          localStorage.setItem(key, String(value));
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
         };
 
-        tileSizeSlider.value = String(clampedValue);
-        applyScale(clampedValue);
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
 
-        tileSizeSlider.addEventListener("input", (event) => {
-          applyScale(Number(event.target.value));
-        });
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
       }
 
 
@@ -689,7 +748,8 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
-        initTileSizeControl();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };

--- a/ds3.html
+++ b/ds3.html
@@ -364,10 +364,14 @@
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
           const atTop = scrollY <= 4;
-          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
           sidebarActive = false;
           navActive = true;
           showNav();

--- a/ds3.html
+++ b/ds3.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Unleash your Ashen One’s true colors in Dark Souls 3 with souls.fashion. This tool helps you discover coordinated armor sets and weapons, creating unforgettable looks for your journey through Lothric.">
 		<meta property="og:site_name" content="Dark Souls III - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -180,7 +185,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.8"></script>
     <script>
 	const gamePrefix = "ds3_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -188,64 +193,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -325,35 +317,10 @@
       });
 
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
-        }
-      });
+      function updateScrollUI() {
+        const scrollY = window.scrollY || window.pageYOffset || 0;
 
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-        }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
-
-      window.addEventListener("scroll", () => {
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +329,35 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -579,6 +557,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +571,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +606,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +651,7 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
     });
 
 };
@@ -678,8 +672,6 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
     });
 });
-
-window.onresize = adjustPinnedStyles;
 
 
   </script>

--- a/eldenring.html
+++ b/eldenring.html
@@ -3,7 +3,7 @@
   <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="description" content="Design perfect color-matching outfits in Elden Ring with souls.fashion. Explore coordinated armor sets, weapons, and accessories for a unique style that suits your Tarnished – the ultimate Elden Ring fashion tool!">
 		<meta property="og:site_name" content="Elden Ring - Fashion Souls" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -115,11 +115,6 @@
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
                 <button id="clearFilter">Clear Filters</button>
-        <div class="tile-size-control">
-          <label for="tileSizeSlider">Tile Size</label>
-          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
-          <p id="tileSizeValue">100%</p>
-        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -184,6 +179,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -345,30 +346,88 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      function initTileSizeControl() {
-        const tileSizeSlider = document.getElementById("tileSizeSlider");
-        const tileSizeValue = document.getElementById("tileSizeValue");
-        if (!tileSizeSlider || !tileSizeValue) {
+      let currentGridScale = 100;
+
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
+        }
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+        }
+
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
           return;
         }
 
-        const key = `${gamePrefix}tileSizeScale`;
-        const savedValue = Number(localStorage.getItem(key)) || 100;
-        const clampedValue = Math.min(130, Math.max(80, savedValue));
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
 
-        const applyScale = (value) => {
-          const scale = value / 100;
-          document.documentElement.style.setProperty("--item-card-scale", String(scale));
-          tileSizeValue.textContent = `${value}%`;
-          localStorage.setItem(key, String(value));
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
         };
 
-        tileSizeSlider.value = String(clampedValue);
-        applyScale(clampedValue);
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
 
-        tileSizeSlider.addEventListener("input", (event) => {
-          applyScale(Number(event.target.value));
-        });
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
       }
 
 
@@ -715,7 +774,8 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
-        initTileSizeControl();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };

--- a/eldenring.html
+++ b/eldenring.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap" />
-    <link rel="stylesheet" href="resources/styles.css?v1.0.8" />
+    <link rel="stylesheet" href="resources/styles.css?v1.0.9" />
     <link rel="icon" type="image/x-icon" href="icon.ico" />
     <link
       rel="apple-touch-icon"
@@ -41,7 +41,7 @@
       sizes="96x96"
       href="favicons/icon_96x96.png"
     />
-    <title>Elden Ring - Fashion Souls v1.0.8</title>
+    <title>Elden Ring - Fashion Souls v1.0.9</title>
   </head>
   <body>
   <div id="preloader" class="preloader">
@@ -209,7 +209,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.8"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "eldenring_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");

--- a/eldenring.html
+++ b/eldenring.html
@@ -114,7 +114,12 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
+        <div class="tile-size-control">
+          <label for="tileSizeSlider">Tile Size</label>
+          <input type="range" id="tileSizeSlider" min="80" max="130" step="5" value="100" />
+          <p id="tileSizeValue">100%</p>
+        </div>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -340,9 +345,35 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      function initTileSizeControl() {
+        const tileSizeSlider = document.getElementById("tileSizeSlider");
+        const tileSizeValue = document.getElementById("tileSizeValue");
+        if (!tileSizeSlider || !tileSizeValue) {
+          return;
+        }
+
+        const key = `${gamePrefix}tileSizeScale`;
+        const savedValue = Number(localStorage.getItem(key)) || 100;
+        const clampedValue = Math.min(130, Math.max(80, savedValue));
+
+        const applyScale = (value) => {
+          const scale = value / 100;
+          document.documentElement.style.setProperty("--item-card-scale", String(scale));
+          tileSizeValue.textContent = `${value}%`;
+          localStorage.setItem(key, String(value));
+        };
+
+        tileSizeSlider.value = String(clampedValue);
+        applyScale(clampedValue);
+
+        tileSizeSlider.addEventListener("input", (event) => {
+          applyScale(Number(event.target.value));
+        });
+      }
+
 
       function updateScrollUI() {
-        const scrollY = window.scrollY || window.pageYOffset || 0;
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
 
         if (window.scrollY > 400) {
           document.querySelector(".back-to-top-button").style.opacity = "1";
@@ -356,7 +387,8 @@
 
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
-          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          const atTop = scrollY <= 4;
+          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
@@ -437,6 +469,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -678,6 +711,7 @@ window.onload = function() {
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
         updateScrollUI();
+        initTileSizeControl();
     });
 
 };

--- a/eldenring.html
+++ b/eldenring.html
@@ -388,10 +388,14 @@
         if (isMobileViewport()) {
           const controlsHeight = nav.offsetHeight || 0;
           const atTop = scrollY <= 4;
-          const shouldShowSidebar = !atTop && scrollY > controlsHeight + 24;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
           setMobileSidebarVisible(shouldShowSidebar);
         } else {
           body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
           sidebarActive = false;
           navActive = true;
           showNav();

--- a/eldenring.html
+++ b/eldenring.html
@@ -6,11 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta name="description" content="Design perfect color-matching outfits in Elden Ring with souls.fashion. Explore coordinated armor sets, weapons, and accessories for a unique style that suits your Tarnished – the ultimate Elden Ring fashion tool!">
 		<meta property="og:site_name" content="Elden Ring - Fashion Souls" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Spectral"
-    />
-    <link rel="stylesheet" href="resources/styles.css?v1.0.5" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap" />
+    <link rel="stylesheet" href="resources/styles.css?v1.0.8" />
     <link rel="icon" type="image/x-icon" href="icon.ico" />
     <link
       rel="apple-touch-icon"
@@ -52,7 +51,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -207,7 +209,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.8"></script>
     <script>
 	const gamePrefix = "eldenring_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -215,64 +217,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -352,35 +341,10 @@
       });
 
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
-        }
-      });
+      function updateScrollUI() {
+        const scrollY = window.scrollY || window.pageYOffset || 0;
 
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-        }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
-
-      window.addEventListener("scroll", () => {
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -389,24 +353,35 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const shouldShowSidebar = scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -608,6 +583,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -617,16 +597,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -635,33 +632,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -687,6 +677,7 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
     });
 
 };
@@ -708,8 +699,6 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
-
-window.onresize = adjustPinnedStyles;
 
 
   </script>

--- a/feedback.html
+++ b/feedback.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">

--- a/feedback.html
+++ b/feedback.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -15,7 +15,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Feedback - Fashion Souls v1.0.8</title>
+    <title>Feedback - Fashion Souls v1.0.9</title>
     
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="description" content="Discover stylish, color-matching outfits for your favorite SoulsBorne games with souls.fashion. Find coordinated looks for Elden Ring, Dark Souls 1-3, Bloodborne, and more – your go-to tool for in-game fashion inspiration!">
+	<meta name="description" content="Curate by colour for the perfect SoulsBourne drip with souls.fashion. Discover outfits for Elden Ring, Dark Souls 1-3, Bloodborne and Demons' Souls with the premier web-hosted fashion tool!">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
@@ -62,14 +62,6 @@
             text-align: center;
         }
 
-        .hero-subtext {
-            font-size: 16px;
-            color: #bfbfbf;
-            text-align: center;
-            margin: 0 auto;
-            max-width: 980px;
-        }
-
         .item-grid {
             display: flex;
             flex-wrap: wrap;
@@ -120,7 +112,6 @@
         @media (max-width: 900px) {
             h2 {font-size: 50px;}
             .hero-title-version {font-size: 18px;}
-            .hero-subtext {font-size: 14px;}
             .item-grid {padding: 14px; gap: 14px;}
         }
     </style>
@@ -129,8 +120,8 @@
 <div class="hero">
     <div class="hero-text">
         <h2>Fashion Souls</h2>
-        <p class="hero-title-version">Fashion Souls v1.0.9</p>
-        <p class="hero-subtext">Curate by colour for the perfect SoulsBourne drip with souls.fashion. Discover outfits for Elden Ring, Dark Souls 1-3, Bloodborne and Demons' Souls with the premier web-hosted fashion tool!</p>
+        <h3 style="color: #bfbfbf">Curate by colour for the perfect SoulsBourne drip with souls.fashion. Discover outfits for Elden Ring, Dark Souls 1-3, Bloodborne and Demons' Souls with the premier web-hosted fashion tool!</h3>
+
     </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
 	<link rel="icon" href="favicon.ico">
     <title>Fashion Souls v1.0.9</title>
     <style>
+        *, *::before, *::after { box-sizing: border-box; }
+
         :root {
             --tile-width: 250px;
         }
@@ -69,6 +71,7 @@
             background-color: #333;
             border: 1px solid #555;
             padding: 14px;
+            flex: 0 1 var(--tile-width);
             width: var(--tile-width);
             text-align: center;
             color: #fff;
@@ -109,7 +112,9 @@
             h3 {font-size: 14px;}
             .item-grid {padding: 14px; gap: 14px;}
             .item-card {
+                flex: 0 1 calc((100% - 14px) / 2);
                 width: calc((100% - 14px) / 2);
+                max-width: calc((100% - 14px) / 2);
                 min-width: 0;
                 padding: 10px;
             }

--- a/index.html
+++ b/index.html
@@ -70,29 +70,6 @@
             max-width: 980px;
         }
 
-        .zoom-controls {
-            max-width: 460px;
-            margin: 0 auto;
-            border: 1px solid #555;
-            border-radius: 8px;
-            padding: 8px 12px;
-            background: #1b1b1b;
-        }
-
-        .zoom-controls label {
-            display: flex;
-            justify-content: space-between;
-            font-size: 14px;
-            color: #d9d9d9;
-            margin-bottom: 6px;
-        }
-
-        .zoom-controls input[type="range"] {
-            width: 100%;
-            accent-color: #d6d6d6;
-            cursor: pointer;
-        }
-
         .item-grid {
             display: flex;
             flex-wrap: wrap;
@@ -155,10 +132,6 @@
         <p class="hero-title-version">Fashion Souls v1.0.9</p>
         <p class="hero-subtext">Curate by colour for the perfect SoulsBourne drip with souls.fashion. Discover outfits for Elden Ring, Dark Souls 1-3, Bloodborne and Demons' Souls with the premier web-hosted fashion tool!</p>
     </div>
-    <div class="zoom-controls">
-        <label for="tileZoom">Tile size <span id="tileZoomValue">100%</span></label>
-        <input type="range" id="tileZoom" min="75" max="130" step="5" value="100">
-    </div>
 </div>
 
 <div class="item-grid" id="itemGrid">
@@ -171,26 +144,6 @@
 </div>
 
 <script>
-    const tileZoomInput = document.getElementById('tileZoom');
-    const tileZoomValue = document.getElementById('tileZoomValue');
-
-    function updateTileZoom(value) {
-        const width = Math.round(250 * (value / 100));
-        document.documentElement.style.setProperty('--tile-width', `${width}px`);
-        tileZoomValue.textContent = `${value}%`;
-        localStorage.setItem('indexTileZoom', String(value));
-    }
-
-    function initTileZoom() {
-        const savedZoom = Number(localStorage.getItem('indexTileZoom')) || 100;
-        const clamped = Math.min(130, Math.max(75, savedZoom));
-        tileZoomInput.value = clamped;
-        updateTileZoom(clamped);
-
-        tileZoomInput.addEventListener('input', (event) => {
-            updateTileZoom(Number(event.target.value));
-        });
-    }
 
     function loadImages() {
         const itemGrid = document.getElementById('itemGrid');
@@ -242,7 +195,6 @@
     }
 
     window.onload = function() {
-        initTileZoom();
         loadImages();
         document.body.classList.remove('fade-out');
     };

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 
         .item-media {
             width: 100%;
-            aspect-ratio: 16 / 10;
+            aspect-ratio: 10 / 16;
             overflow: hidden;
             background: #202020;
         }

--- a/index.html
+++ b/index.html
@@ -56,11 +56,6 @@
             margin-bottom: 12px;
         }
 
-        .hero-title-version {
-            font-size: 22px;
-            color: #d8d8d8;
-            text-align: center;
-        }
 
         .item-grid {
             display: flex;
@@ -111,8 +106,13 @@
 
         @media (max-width: 900px) {
             h2 {font-size: 50px;}
-            .hero-title-version {font-size: 18px;}
+            h3 {font-size: 14px;}
             .item-grid {padding: 14px; gap: 14px;}
+            .item-card {
+                width: calc((100% - 14px) / 2);
+                min-width: 0;
+                padding: 10px;
+            }
         }
     </style>
 </head>
@@ -120,7 +120,7 @@
 <div class="hero">
     <div class="hero-text">
         <h2>Fashion Souls</h2>
-        <h3 style="color: #bfbfbf">Curate by colour for the perfect SoulsBourne drip with souls.fashion. Discover outfits for Elden Ring, Dark Souls 1-3, Bloodborne and Demons' Souls with the premier web-hosted fashion tool!</h3>
+        <h3 style="color: #bfbfbf">SoulsBorne Fashion Tool by Psyopgirl</h3>
 
     </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -8,73 +8,159 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-		<link rel="icon" type="image/x-icon" href="icon.ico">
-		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
-		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
-		<link rel="icon" type="image/png" sizes="48x48" href="favicons/icon_48x48.png">
-		<link rel="icon" type="image/png" sizes="96x96" href="favicons/icon_96x96.png">
-		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
-		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
-		<link rel="icon" href="favicon.ico">
-    <title>Fashion Souls v1.0.8</title>
+	<link rel="icon" type="image/x-icon" href="icon.ico">
+	<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
+	<link rel="icon" type="image/png" sizes="48x48" href="favicons/icon_48x48.png">
+	<link rel="icon" type="image/png" sizes="96x96" href="favicons/icon_96x96.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
+	<link rel="icon" href="favicon.ico">
+    <title>Fashion Souls v1.0.9</title>
     <style>
-        h2 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 70px;margin-top:-10px;}
-        h3 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 20px;margin-top:-70px;}
+        :root {
+            --tile-width: 250px;
+        }
+
+        h2 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 70px;margin: 0;}
+        h3 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 20px;margin: 0;}
+
         body {
             font-family: "Spectral", 'fallback', Helvetica, Arial, sans-serif;
             margin: 0;
-            padding: 20px;
+            padding: 0;
             background-color: #121212;
             color: #ffffff;
-            transition: background-color 0.5s ease, color 0.5s ease, opacity 0.5s ease; /* Combined transitions */
+            transition: background-color 0.5s ease, color 0.5s ease, opacity 0.5s ease;
             opacity: 1;
-            visibility: visible; /* Initial visibility */
-            padding-bottom: 40px; /* Add padding at the bottom to prevent content overlap */
+            visibility: visible;
+            padding-bottom: 55px;
         }
-        .fade-out {
-            opacity: 0; /* Fade-out effect */
-            visibility: hidden; /* Hide the body */
+
+        .fade-out {opacity: 0;visibility: hidden;}
+
+        .hero {
+            position: sticky;
+            top: 0;
+            z-index: 20;
+            background: rgba(18, 18, 18, 0.95);
+            backdrop-filter: blur(4px);
+            padding: 14px 16px 12px;
+            border-bottom: 1px solid #333;
         }
+
+        .hero-text {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+
+        .hero-title-version {
+            font-size: 22px;
+            color: #d8d8d8;
+            text-align: center;
+        }
+
+        .hero-subtext {
+            font-size: 16px;
+            color: #bfbfbf;
+            text-align: center;
+            margin: 0 auto;
+            max-width: 980px;
+        }
+
+        .zoom-controls {
+            max-width: 460px;
+            margin: 0 auto;
+            border: 1px solid #555;
+            border-radius: 8px;
+            padding: 8px 12px;
+            background: #1b1b1b;
+        }
+
+        .zoom-controls label {
+            display: flex;
+            justify-content: space-between;
+            font-size: 14px;
+            color: #d9d9d9;
+            margin-bottom: 6px;
+        }
+
+        .zoom-controls input[type="range"] {
+            width: 100%;
+            accent-color: #d6d6d6;
+            cursor: pointer;
+        }
+
         .item-grid {
             display: flex;
             flex-wrap: wrap;
             gap: 20px;
-            justify-content: center; /* Center the grid */
+            justify-content: center;
+            padding: 20px;
         }
+
         .item-card {
             background-color: #333;
             border: 1px solid #555;
-            padding: 20px; /* Increased padding for a larger tile */
-            width: 250px; /* Adjust width for larger tiles */
+            padding: 14px;
+            width: var(--tile-width);
             text-align: center;
             color: #fff;
+            transition: width 0.2s ease, transform 0.2s ease;
         }
-        .item-card img {
+
+        .item-card:hover {transform: translateY(-2px);}
+
+        .item-media {
             width: 100%;
-            aspect-ratio: 1 / 1;
-            max-width: 100%;
-            height: auto;
+            aspect-ratio: 16 / 10;
+            overflow: hidden;
+            background: #202020;
+        }
+
+        .item-card img {
+            display: block;
+            width: 100%;
+            height: 100%;
             object-fit: cover;
         }
+
         .copyright {
-            position: fixed; /* Fix to the bottom */
-            bottom: 0; /* Position at the bottom of the viewport */
-            left: 0; /* Align to the left */
-            right: 0; /* Align to the right */
-            text-align: center; /* Center the copyright text */
-            margin: 0; /* Remove margin */
-            padding: 10px 0; /* Padding for spacing */
-            font-size: 14px; /* Font size for the copyright */
-            color: #333333; /* Color for the copyright text */
-            background-color: rgba(18, 18, 18, 0.8); /* Background color with some transparency */
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            text-align: center;
+            margin: 0;
+            padding: 10px 0;
+            font-size: 14px;
+            color: #333333;
+            background-color: rgba(18, 18, 18, 0.8);
+        }
+
+        @media (max-width: 900px) {
+            h2 {font-size: 50px;}
+            .hero-title-version {font-size: 18px;}
+            .hero-subtext {font-size: 14px;}
+            .item-grid {padding: 14px; gap: 14px;}
         }
     </style>
 </head>
 <body>
-<div class="FashionSouls">
-    <h2>Fashion Souls</h2>
-    <h3 style="color: #bfbfbf">SoulsBorne fashion tool by Psyopgirl</h3>
+<div class="hero">
+    <div class="hero-text">
+        <h2>Fashion Souls</h2>
+        <p class="hero-title-version">Fashion Souls v1.0.9</p>
+        <p class="hero-subtext">Curate by colour for the perfect SoulsBourne drip with souls.fashion. Discover outfits for Elden Ring, Dark Souls 1-3, Bloodborne and Demons' Souls with the premier web-hosted fashion tool!</p>
+    </div>
+    <div class="zoom-controls">
+        <label for="tileZoom">Tile size <span id="tileZoomValue">100%</span></label>
+        <input type="range" id="tileZoom" min="75" max="130" step="5" value="100">
+    </div>
 </div>
+
 <div class="item-grid" id="itemGrid">
     <!-- Images will be dynamically loaded here -->
 </div>
@@ -85,49 +171,46 @@
 </div>
 
 <script>
-    // Function to load images dynamically with placeholders
+    const tileZoomInput = document.getElementById('tileZoom');
+    const tileZoomValue = document.getElementById('tileZoomValue');
+
+    function updateTileZoom(value) {
+        const width = Math.round(250 * (value / 100));
+        document.documentElement.style.setProperty('--tile-width', `${width}px`);
+        tileZoomValue.textContent = `${value}%`;
+        localStorage.setItem('indexTileZoom', String(value));
+    }
+
+    function initTileZoom() {
+        const savedZoom = Number(localStorage.getItem('indexTileZoom')) || 100;
+        const clamped = Math.min(130, Math.max(75, savedZoom));
+        tileZoomInput.value = clamped;
+        updateTileZoom(clamped);
+
+        tileZoomInput.addEventListener('input', (event) => {
+            updateTileZoom(Number(event.target.value));
+        });
+    }
+
     function loadImages() {
         const itemGrid = document.getElementById('itemGrid');
         const items = [
-            {
-                img: 'https://i.ibb.co/Zz6L6c6/elden-ring-grid.webp',
-                placeholder: 'resources/grid-images/elden-ring-grid_placeholder.webp',
-                link: 'eldenring'
-            },
-            {
-                img: 'https://i.ibb.co/0Zk0dbB/bloodborne-grid.webp',
-                placeholder: 'resources/grid-images/bloodborne-grid_placeholder.webp',
-                link: 'bloodborne'
-            },
-            {
-                img: 'https://i.ibb.co/1rLcBQG/dark-souls-grid.webp',
-                placeholder: 'resources/grid-images/dark-souls-grid_placeholder.webp',
-                link: 'ds1'
-            },
-            {
-                img: 'https://i.ibb.co/gFfpdmD/dark-souls-2-grid.webp',
-                placeholder: 'resources/grid-images/dark-souls-2-grid_placeholder.webp',
-                link: 'ds2'
-            },
-            {
-                img: 'https://i.ibb.co/NT663zC/dark-souls-3-grid.webp',
-                placeholder: 'resources/grid-images/dark-souls-3-grid_placeholder.webp',
-                link: 'ds3'
-            },
-            {
-                img: 'https://i.ibb.co/zRmBHft/demons-souls-grid.webp',
-                placeholder: 'resources/grid-images/demons-souls-grid_placeholder.webp',
-                link: 'demonssouls'
-            }
+            {img: 'https://i.ibb.co/Zz6L6c6/elden-ring-grid.webp', placeholder: 'resources/grid-images/elden-ring-grid_placeholder.webp', link: 'eldenring'},
+            {img: 'https://i.ibb.co/0Zk0dbB/bloodborne-grid.webp', placeholder: 'resources/grid-images/bloodborne-grid_placeholder.webp', link: 'bloodborne'},
+            {img: 'https://i.ibb.co/1rLcBQG/dark-souls-grid.webp', placeholder: 'resources/grid-images/dark-souls-grid_placeholder.webp', link: 'ds1'},
+            {img: 'https://i.ibb.co/gFfpdmD/dark-souls-2-grid.webp', placeholder: 'resources/grid-images/dark-souls-2-grid_placeholder.webp', link: 'ds2'},
+            {img: 'https://i.ibb.co/NT663zC/dark-souls-3-grid.webp', placeholder: 'resources/grid-images/dark-souls-3-grid_placeholder.webp', link: 'ds3'},
+            {img: 'https://i.ibb.co/zRmBHft/demons-souls-grid.webp', placeholder: 'resources/grid-images/demons-souls-grid_placeholder.webp', link: 'demonssouls'}
         ];
 
-        itemGrid.innerHTML = ''; // Clear existing content
+        itemGrid.innerHTML = '';
 
         items.forEach(item => {
             const itemCard = document.createElement('div');
             itemCard.className = 'item-card';
-            const linkElement = document.createElement('a');
 
+            const linkElement = document.createElement('a');
+            linkElement.href = item.link;
             linkElement.addEventListener('click', function(e) {
                 e.preventDefault();
                 document.body.classList.add('fade-out');
@@ -136,41 +219,41 @@
                 }, 500);
             });
 
+            const mediaElement = document.createElement('div');
+            mediaElement.className = 'item-media';
+
             const imgElement = document.createElement('img');
             imgElement.loading = 'lazy';
             imgElement.decoding = 'async';
-            imgElement.src = item.placeholder; // Load the placeholder initially
+            imgElement.src = item.placeholder;
             imgElement.alt = item.link;
 
-            // Load the animated image after placeholder is loaded
             const animatedImg = new Image();
             animatedImg.src = item.img;
             animatedImg.onload = function() {
-                imgElement.src = animatedImg.src; // Replace with animated image
+                imgElement.src = animatedImg.src;
             };
 
-            linkElement.appendChild(imgElement);
+            mediaElement.appendChild(imgElement);
+            linkElement.appendChild(mediaElement);
             itemCard.appendChild(linkElement);
             itemGrid.appendChild(itemCard);
         });
     }
 
-    // Call the function to load images on page load
     window.onload = function() {
+        initTileZoom();
         loadImages();
-        document.body.classList.remove('fade-out'); // Ensure fade-out is removed on load
+        document.body.classList.remove('fade-out');
     };
 
-    // Listen for visibility change to manage the fade-in effect
     document.addEventListener('visibilitychange', function() {
         if (document.visibilityState === 'visible') {
-            document.body.classList.remove('fade-out'); // Remove fade-out when coming back
+            document.body.classList.remove('fade-out');
         } else {
-            document.body.classList.add('fade-out'); // Add fade-out when leaving
+            document.body.classList.add('fade-out');
         }
     });
 </script>
-
-
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Discover stylish, color-matching outfits for your favorite SoulsBorne games with souls.fashion. Find coordinated looks for Elden Ring, Dark Souls 1-3, Bloodborne, and more – your go-to tool for in-game fashion inspiration!">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -48,8 +50,11 @@
             color: #fff;
         }
         .item-card img {
+            width: 100%;
+            aspect-ratio: 1 / 1;
             max-width: 100%;
             height: auto;
+            object-fit: cover;
         }
         .copyright {
             position: fixed; /* Fix to the bottom */
@@ -132,6 +137,8 @@
             });
 
             const imgElement = document.createElement('img');
+            imgElement.loading = 'lazy';
+            imgElement.decoding = 'async';
             imgElement.src = item.placeholder; // Load the placeholder initially
             imgElement.alt = item.link;
 

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -3,6 +3,11 @@
   user-select: none;
 }
 
+img {
+  -webkit-user-drag: none;
+  -webkit-touch-callout: none;
+}
+
 h2 {
   letter-spacing: -0.25rem; /* -4px */
   line-height: 0.5;
@@ -459,6 +464,7 @@ body.light-mode .dropdown .dropbtn {
   vertical-align: middle;
   text-align: center;
   margin-left: 6.5rem;
+  transition: margin-left 0.3s ease;
 }
 
 .item-card {
@@ -473,6 +479,13 @@ body.light-mode .dropdown .dropbtn {
   color: #fff;
   transition: transform 0.3s ease, border-color 0.3s ease;
   border-radius: 0.625rem; /* 10px */
+  touch-action: pan-y;
+}
+
+.item-card.dragging {
+  opacity: 0.75;
+  transform: scale(1.02);
+  border-color: #8c8c8c;
 }
 
 .item-card-simple {
@@ -515,8 +528,15 @@ body.light-mode .item-card-simple {
 }
 
 .item-card img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
   max-width: 100%;
   height: auto;
+  object-fit: contain;
+}
+
+.image-container {
+  aspect-ratio: 1 / 1;
 }
 
 .image-container,
@@ -640,6 +660,10 @@ body.light-mode .color-bar div:hover {
   transform: translateY(-50%);
 }
 
+body.is-dragging-item .pinned {
+  box-shadow: 0 0 0.5rem rgba(255, 235, 59, 0.6);
+}
+
 body.light-mode .pinned {
   border: 0.0625rem solid #999; /* 1px */
   background-color: white;
@@ -718,6 +742,12 @@ body.light-mode .pinned {
   z-index: 1001;
   border: 0.0625rem solid #555; /* 1px */
   border-radius: 0.625rem; /* 10px */
+}
+
+.slot.drop-target img,
+.slot.drop-target .placeholder-tile {
+  outline: 0.125rem dashed #ffeb3b;
+  outline-offset: 0.125rem;
 }
 
 .back-to-top-button {
@@ -1109,6 +1139,9 @@ body.light-mode .custom-context-menu ul li:hover {
   .navigation {
     padding-right: 5%;
     padding-left: 5%;
+    position: sticky;
+    max-height: 100dvh;
+    overflow-y: auto;
   }
 
   .topnav-simple {
@@ -1215,6 +1248,10 @@ body.light-mode .custom-context-menu ul li:hover {
     margin-left: 0;
   }
 
+  body.mobile-sidebar-visible .item-grid {
+    margin-left: 4.8rem;
+  }
+
   .item-card {
     width: 40%;
     height: auto;
@@ -1240,10 +1277,18 @@ body.light-mode .custom-context-menu ul li:hover {
   .pinned {
     top: 50%;
     left: 0;
-    transform: translateY(-50%);
+    transform: translate(-120%, -50%);
     opacity: 0;
-    display: none;
-    width: 3.75rem; /* 60px */
+    display: block;
+    width: 4.5rem;
+    max-height: calc(100dvh - 1rem);
+    overflow-y: auto;
+    transition: transform 0.25s ease, opacity 0.25s ease;
+  }
+
+  body.mobile-sidebar-visible .pinned {
+    transform: translate(0, -50%);
+    opacity: 1;
   }
 
   .pinned-buttons button {
@@ -1296,7 +1341,12 @@ body.light-mode .custom-context-menu ul li:hover {
   }
 
   .hover-trigger {
-    width: 2rem;
+    width: 4.5rem;
+    pointer-events: none;
+  }
+
+  .hover-trigger .pinned {
+    pointer-events: auto;
   }
 }
 
@@ -1423,11 +1473,21 @@ body.light-mode .custom-context-menu ul li:hover {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 3000;
     text-align: center;
+    padding: 1rem;
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.3s ease;
+}
+
+.notice-content {
+    max-width: 40rem;
+    line-height: 1.5;
+}
+
+.notice-content a {
+    color: #ffeb3b;
 }
 
 .full-screen-notice.show {

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -419,30 +419,84 @@ body.light-mode .filters-group button.active {
   border-color: #007bff;
 }
 
-.tile-size-control {
+.grid-zoom-control {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  border: 0.0625rem solid #555;
-  border-radius: 0.375rem;
-  padding: 0.25rem 0.5rem;
+  justify-content: center;
+  gap: 0.45rem;
+  margin-bottom: 0.35rem;
+  padding: 0.35rem 0.3rem;
+  border: 0.0625rem solid #3f3f3f;
+  border-radius: 0.5rem;
+  background-color: rgba(20, 20, 20, 0.92);
 }
 
-.tile-size-control label {
-  font-size: 0.75rem;
+.grid-zoom-control .zoom-symbol {
+  color: #d6d6d6;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1;
 }
 
-.tile-size-control input[type="range"] {
-  width: 6rem;
-  accent-color: #d6d6d6;
+.grid-zoom-control input[type="range"] {
+  width: 3.2rem;
 }
 
-.tile-size-control p {
-  margin: 0;
-  min-width: 2.25rem;
-  font-size: 0.7rem;
-  text-align: right;
+.grid-zoom-value {
+  margin: 0 0 0.45rem 0;
+  text-align: center;
+  color: #a8a8a8;
+  font-size: 0.68rem;
 }
+
+.slider-container input[type="range"],
+.grid-zoom-control input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 0.275rem;
+  border-radius: 999px;
+  background: #2d2d2d;
+  outline: none;
+  border: 0.0625rem solid #4a4a4a;
+}
+
+.slider-container input[type="range"]::-webkit-slider-thumb,
+.grid-zoom-control input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  background: #d9d9d9;
+  border: 0.125rem solid #2f2f2f;
+  cursor: pointer;
+}
+
+.slider-container input[type="range"]::-moz-range-thumb,
+.grid-zoom-control input[type="range"]::-moz-range-thumb {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  background: #d9d9d9;
+  border: 0.125rem solid #2f2f2f;
+  cursor: pointer;
+}
+
+body.light-mode .slider-container input[type="range"],
+body.light-mode .grid-zoom-control input[type="range"] {
+  background: #d8d8d8;
+  border-color: #b8b8b8;
+}
+
+body.light-mode .grid-zoom-control {
+  background-color: rgba(245, 245, 245, 0.95);
+  border-color: #bbbbbb;
+}
+
+body.light-mode .grid-zoom-control .zoom-symbol,
+body.light-mode .grid-zoom-value {
+  color: #222;
+}
+
 
 .dropdown .dropbtn {
   all: unset;
@@ -1353,6 +1407,11 @@ body.light-mode .custom-context-menu ul li:hover {
     font-size: 0.75rem; /* 12px */
   }
 
+  .grid-zoom-control,
+  .grid-zoom-value {
+    display: none;
+  }
+
   .placeholder-tile {
     font-size: 0.45rem;
   }
@@ -1401,15 +1460,6 @@ body.light-mode .custom-context-menu ul li:hover {
     pointer-events: none;
   }
 
-  .tile-size-control {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .tile-size-control input[type="range"] {
-    width: 100%;
-    max-width: 7rem;
-  }
 
   .hover-trigger .pinned {
     pointer-events: auto;

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -8,6 +8,10 @@ img {
   -webkit-touch-callout: none;
 }
 
+:root {
+  --item-card-scale: 1;
+}
+
 h2 {
   letter-spacing: -0.25rem; /* -4px */
   line-height: 0.5;
@@ -414,6 +418,31 @@ body.light-mode .filters-group button.active {
   border-color: #007bff;
 }
 
+.tile-size-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 0.0625rem solid #555;
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.tile-size-control label {
+  font-size: 0.75rem;
+}
+
+.tile-size-control input[type="range"] {
+  width: 6rem;
+  accent-color: #d6d6d6;
+}
+
+.tile-size-control p {
+  margin: 0;
+  min-width: 2.25rem;
+  font-size: 0.7rem;
+  text-align: right;
+}
+
 .dropdown .dropbtn {
   all: unset;
   text-decoration: none;
@@ -473,11 +502,12 @@ body.light-mode .dropdown .dropbtn {
   background-color: none;
   border: 0.0625rem solid #555; /* 1px */
   padding: 0.625rem; /* 10px */
-  width: 12.5rem; /* 200px */
-  height: 18.75rem; /* 300px */
+  width: calc(12.5rem * var(--item-card-scale)); /* 200px */
+  height: calc(18.75rem * var(--item-card-scale)); /* 300px */
   text-align: center;
   color: #fff;
-  transition: transform 0.3s ease, border-color 0.3s ease;
+  transition: transform 0.3s ease, border-color 0.3s ease, width 0.2s ease,
+    height 0.2s ease;
   border-radius: 0.625rem; /* 10px */
   touch-action: pan-y;
 }
@@ -528,6 +558,8 @@ body.light-mode .item-card-simple {
 }
 
 .item-card img {
+  pointer-events: none;
+  user-select: none;
   width: 100%;
   aspect-ratio: 1 / 1;
   max-width: 100%;
@@ -736,6 +768,8 @@ body.light-mode .pinned {
 }
 
 .slot img {
+  pointer-events: none;
+  user-select: none;
   width: 100%;
   height: auto;
   background-color: #000;
@@ -1253,7 +1287,7 @@ body.light-mode .custom-context-menu ul li:hover {
   }
 
   .item-card {
-    width: 40%;
+    width: calc(40% * var(--item-card-scale));
     height: auto;
   }
 
@@ -1312,7 +1346,7 @@ body.light-mode .custom-context-menu ul li:hover {
   }
 
   .back-to-top-button {
-    font-size: 0.625rem; /* 10px */
+    font-size: 0.875rem; /* 14px */
     margin: 0.625rem; /* 10px */
   }
 
@@ -1343,6 +1377,16 @@ body.light-mode .custom-context-menu ul li:hover {
   .hover-trigger {
     width: 4.5rem;
     pointer-events: none;
+  }
+
+  .tile-size-control {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .tile-size-control input[type="range"] {
+    width: 100%;
+    max-width: 7rem;
   }
 
   .hover-trigger .pinned {

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -10,6 +10,7 @@ img {
 
 :root {
   --item-card-scale: 1;
+  --mobile-controls-offset: 11.25rem;
 }
 
 h2 {
@@ -765,6 +766,10 @@ body.light-mode .pinned {
   position: absolute;
   vertical-align: middle;
   color: #777;
+  font-size: 0.55rem;
+  line-height: 1.15;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .slot img {
@@ -1178,6 +1183,17 @@ body.light-mode .custom-context-menu ul li:hover {
     overflow-y: auto;
   }
 
+  .topnav {
+    position: sticky;
+    top: 0;
+    z-index: 1002;
+    background-color: #121212;
+  }
+
+  body.light-mode .topnav {
+    background-color: #fff;
+  }
+
   .topnav-simple {
     display: flex;
     flex-direction: row-reverse;
@@ -1309,20 +1325,25 @@ body.light-mode .custom-context-menu ul li:hover {
   }
 
   .pinned {
-    top: 50%;
+    top: calc(var(--mobile-controls-offset) + 0.5rem);
     left: 0;
-    transform: translate(-120%, -50%);
+    transform: translate(-120%, 0);
     opacity: 0;
     display: block;
-    width: 4.5rem;
-    max-height: calc(100dvh - 1rem);
+    width: 5.25rem;
+    max-height: calc(100dvh - var(--mobile-controls-offset) - 0.75rem);
     overflow-y: auto;
     transition: transform 0.25s ease, opacity 0.25s ease;
   }
 
   body.mobile-sidebar-visible .pinned {
-    transform: translate(0, -50%);
+    transform: translate(0, 0);
     opacity: 1;
+  }
+
+  body.mobile-controls-visible .pinned {
+    transform: translate(-120%, 0);
+    opacity: 0;
   }
 
   .pinned-buttons button {
@@ -1333,16 +1354,17 @@ body.light-mode .custom-context-menu ul li:hover {
   }
 
   .placeholder-tile {
-    font-size: 0.375rem; /* 6px */
+    font-size: 0.45rem;
   }
 
   .placeholder-tile p {
-    font-size: 0.5rem;
+    font-size: 0.55rem;
+    line-height: 1.15;
   }
 
   .slot {
-    width: 3.125rem; /* 50px */
-    height: 3.125rem; /* 50px */
+    width: 4.2rem;
+    height: 4.2rem;
   }
 
   .back-to-top-button {
@@ -1391,6 +1413,98 @@ body.light-mode .custom-context-menu ul li:hover {
 
   .hover-trigger .pinned {
     pointer-events: auto;
+  }
+}
+
+@media (min-width: 0px) and (max-width: 1199px) {
+  #backToMain {
+    width: auto;
+    max-width: 64vw;
+    font-size: 0.72rem;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .outfit-sim {
+    align-items: stretch;
+    padding: 3.1rem 5.8rem 0.5rem 0.5rem;
+  }
+
+  .outfit-sim-header h1 {
+    font-size: 0.95rem;
+    line-height: 1.25;
+    margin: 0 0 0.35rem 0;
+  }
+
+  #downloadImageLink {
+    font-size: 0.75rem;
+    margin: 0.15rem 0 0.5rem 0;
+  }
+
+  #presetContainer {
+    top: 2.8rem;
+    right: 0.25rem;
+    transform: none;
+    width: 5.2rem;
+    padding: 0.35rem;
+    gap: 0.35rem;
+    max-height: calc(100dvh - 3.3rem);
+    overflow-y: auto;
+    border-radius: 0.4rem;
+  }
+
+  .preset {
+    width: 100%;
+    padding: 0.35rem;
+    border-radius: 0.35rem;
+  }
+
+  .preset h3 {
+    font-size: 0.58rem;
+    margin: 0;
+    line-height: 1.2;
+    min-height: 1.2rem;
+  }
+
+  .preset-actions {
+    margin-top: 0.2rem;
+    line-height: 1.1;
+  }
+
+  .preset-actions span {
+    font-size: 0.5rem;
+  }
+
+  #outfitSlotsSimulator.simulator-grid {
+    width: 100%;
+    gap: 0.4rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  #headCard,
+  #chestCard,
+  #handsCard,
+  #legsCard,
+  #weaponsCard,
+  #shieldsCard {
+    width: 100%;
+    min-width: 0;
+    height: auto;
+    min-height: 8.4rem;
+    padding: 0.35rem;
+    border-radius: 0.45rem;
+    font-size: 0.58rem;
+  }
+
+  #outfitSlotsSimulator .item-card-simple img,
+  #headCard img,
+  #chestCard img,
+  #handsCard img,
+  #legsCard img,
+  #weaponsCard img,
+  #shieldsCard img {
+    max-height: 4.5rem;
+    width: 100%;
+    object-fit: contain;
   }
 }
 

--- a/search_items.js
+++ b/search_items.js
@@ -188,6 +188,8 @@ function createItemCard(item) {
   const imageContainer = document.createElement("div");
   imageContainer.classList.add("image-container");
   const img = document.createElement("img");
+  img.loading = "lazy";
+  img.decoding = "async";
   img.src = `pages/${page}/icons/${item.image}`;
   img.alt = item.name;
   imageContainer.appendChild(img);

--- a/search_items.js
+++ b/search_items.js
@@ -190,6 +190,7 @@ function createItemCard(item) {
   const img = document.createElement("img");
   img.loading = "lazy";
   img.decoding = "async";
+  img.draggable = false;
   img.src = `pages/${page}/icons/${item.image}`;
   img.alt = item.name;
   imageContainer.appendChild(img);

--- a/simulator_bloodborne.html
+++ b/simulator_bloodborne.html
@@ -6,9 +6,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Bloodborne Outfit Simulator</title>
-	<title>Bloodborne outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Bloodborne outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="bloodborne" id="backToMain" class="back-link">← Back to Bloodborne Outfit Selection</a>

--- a/simulator_bloodborne.html
+++ b/simulator_bloodborne.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
     <title>Bloodborne Outfit Simulator</title>
 	<title>Bloodborne outfit simulator - Fashion Souls v1.0.8</title>
 </head>

--- a/simulator_demonssouls.html
+++ b/simulator_demonssouls.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
     <title>Demon's Souls Outfit Simulator</title>
 	<title>Demon's Souls outfit simulator - Fashion Souls v1.0.8</title>
 </head>

--- a/simulator_demonssouls.html
+++ b/simulator_demonssouls.html
@@ -6,9 +6,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Demon's Souls Outfit Simulator</title>
-	<title>Demon's Souls outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Demon's Souls outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="demonssouls" id="backToMain" class="back-link">← Back to Demon's Souls Outfit Selection</a>

--- a/simulator_ds1.html
+++ b/simulator_ds1.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
     <title>Dark Souls Outfit Simulator</title>
 	<title>Dark Souls outfit simulator - Fashion Souls v1.0.8</title>
 </head>

--- a/simulator_ds1.html
+++ b/simulator_ds1.html
@@ -6,9 +6,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Dark Souls Outfit Simulator</title>
-	<title>Dark Souls outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Dark Souls outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="ds1" id="backToMain" class="back-link">← Back to Dark Souls Outfit Selection</a>

--- a/simulator_ds2.html
+++ b/simulator_ds2.html
@@ -6,8 +6,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
-    <title>Dark Souls 2 outfit simulator - Fashion Souls v1.0.8</title>
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
+    <title>Dark Souls 2 outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="ds2" id="backToMain" class="back-link">← Back to Dark Souls 2 Outfit Selection</a>

--- a/simulator_ds2.html
+++ b/simulator_ds2.html
@@ -3,10 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
-    <title>Dark Souls 2 Outfit Simulator</title>
-	<title>Dark Souls 2 outfit simulator - Fashion Souls v1.0.8</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+    <title>Dark Souls 2 outfit simulator - Fashion Souls v1.0.8</title>
 </head>
 <body>
     <a href="ds2" id="backToMain" class="back-link">← Back to Dark Souls 2 Outfit Selection</a>
@@ -66,62 +67,6 @@
 
 <script>
 	const gamePrefix = "ds2_"; // Unique prefix for LocalStorage handling
-    // Function to edit a preset name
-    function editPresetName(presetNumber) {
-        const presetNameElement = document.getElementById(`presetName${presetNumber}`);
-        
-        // Save the original name in case the user doesn't enter a new one
-        const originalName = presetNameElement.textContent.trim();
-
-        // Clear the text when clicked to edit
-        presetNameElement.textContent = "";
-
-        // Save the updated name when focus is lost
-        presetNameElement.addEventListener("blur", () => {
-            const name = presetNameElement.textContent.trim();
-
-            if (name === "") {
-                // If no new name is provided, revert to the original name
-                presetNameElement.textContent = originalName;
-            } else {
-                // Otherwise, save the new name
-                localStorage.setItem(gamePrefix + `presetName${presetNumber}`, name);
-            }
-        }, { once: true });
-
-        // Save the updated name when the Enter key is pressed
-        presetNameElement.addEventListener("keydown", (event) => {
-            if (event.key === "Enter") {
-                event.preventDefault(); // Prevent newline
-                presetNameElement.blur(); // Trigger blur event to save
-            }
-        });
-    }
-
-    // Function to load preset names from localStorage
-    function loadPresetNames() {
-        for (let i = 1; i <= 5; i++) {
-            const name = localStorage.getItem(gamePrefix + `presetName${i}`) || `Preset ${i}`;
-            document.getElementById(`presetName${i}`).textContent = name;
-        }
-    }
-
-    // Function to clear a preset
-    function clearPreset(presetNumber) {
-        localStorage.removeItem(gamePrefix + `preset${presetNumber}`);
-    }
-
- 
-    // Load preset names and outfit on page load
-    document.addEventListener("DOMContentLoaded", () => {
-        loadPresetNames();
-        loadOutfitFromStorage();
-    });
-</script>
-
-
-
-<script>
     // Function to edit a preset name
     function editPresetName(presetNumber) {
         const presetNameElement = document.getElementById(`presetName${presetNumber}`);
@@ -329,25 +274,6 @@
         loadOutfitFromStorage();
     });
 	
-	//dismiss full-screen notice
-	document.addEventListener("DOMContentLoaded", () => {
-    const fullScreenNotice = document.getElementById('fullScreenNotice');
-    const dismissNotice = document.getElementById('dismissNotice');
-
-    // Check if the notice has already been dismissed
-    if (!localStorage.getItem('noticeDismissed')) {
-        fullScreenNotice.style.display = 'flex'; // Show the notice overlay
-    } else {
-        fullScreenNotice.style.display = 'none'; // Hide it if already dismissed
-    }
-
-    // Add click event to dismiss the notice
-    dismissNotice.addEventListener('click', (event) => {
-        event.preventDefault();
-        fullScreenNotice.style.display = 'none'; // Hide the notice
-        localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
-    });
-});
 
 </script>
 

--- a/simulator_ds3.html
+++ b/simulator_ds3.html
@@ -6,9 +6,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Dark Souls 3 Outfit Simulator</title>
-	<title>Dark Souls 3 outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Dark Souls 3 outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="ds3" id="backToMain" class="back-link">← Back to Dark Souls 3 Outfit Selection</a>

--- a/simulator_ds3.html
+++ b/simulator_ds3.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
     <title>Dark Souls 3 Outfit Simulator</title>
 	<title>Dark Souls 3 outfit simulator - Fashion Souls v1.0.8</title>
 </head>

--- a/simulator_eldenring.html
+++ b/simulator_eldenring.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
     <title>Elden Ring Outfit Simulator</title>
 	<title>Elden Ring outfit simulator - Fashion Souls v1.0.8</title>
 </head>

--- a/simulator_eldenring.html
+++ b/simulator_eldenring.html
@@ -6,9 +6,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.8">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Elden Ring Outfit Simulator</title>
-	<title>Elden Ring outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Elden Ring outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="eldenring" id="backToMain" class="back-link">← Back to Elden Ring Outfit Selection</a>


### PR DESCRIPTION
### Motivation
- Improve mobile scrolling and sidebar visibility behavior, reduce scroll jank, and make the pinned outfit sidebar more robust across viewports.
- Enhance drag-and-drop UX for outfit slots with clearer visual feedback and simpler drop handling.
- Update font loading pattern to use `preconnect` and `googleapis` v2, and bump styles/scripts to the new `v1.0.8` asset version.

### Description
- Reworked scroll/nav/sidebar logic across multiple pages to use `isMobileViewport()`, `setMobileSidebarVisible()`, `updateScrollUI()` and an RAF-throttled `onScroll()` handler, and added a `resize` listener to call `adjustPinnedStyles()` and `updateScrollUI()`.
- Replaced ad-hoc show/hide DOM tweaks with a `mobile-sidebar-visible` body class for mobile layout adjustments and removed several deprecated touch/wheel handlers.
- Improved drag-and-drop in `initializeDragAndDrop()` by selecting per-slot elements, adding `dragover`/`dragleave` handlers, `drop` handling that consults the already-loaded `items` array (instead of fetching JSON), and adding visual states: `dragging`, `is-dragging-item`, and `drop-target` classes, plus `dataTransfer.effectAllowed` usage.
- Updated many HTML files (index, game pages, simulator pages, feedback) to use `preconnect` for Google Fonts and the new `css2` Spectral URL, and bumped stylesheet/script versions to `resources/styles.css?v1.0.8` and `search_items.js?v1.0.8`.
- Added lazy/deferred image loading improvements (`loading='lazy'`, `decoding='async'`) for grid and item images, and added `img` CSS rules to disable user-drag and improve layout with `aspect-ratio` and `object-fit`.
- CSS updates in `resources/styles.css` include drag/drop visual styles (outline on `.slot.drop-target`), `.item-card.dragging` styling, `.pinned` mobile behavior and transitions, `.full-screen-notice` layout and `.notice-content` styles, and a handful of mobile layout refinements including `position: sticky` and `overflow-y` improvements.
- Replaced the generic cache notice text in full-screen notice with a short community support message linking to `https://ko-fi.com/psyopgirl` and kept the cache / ctrl+F5 guidance.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1503900208325b04402d0621717dc)