### PR TITLE
Add grid zoom/pinch-zoom, improved mobile sidebar & drag-and-drop UX, preloader and asset updates (v1.0.9)

### DIFF
--- a/bloodborne.html
+++ b/bloodborne.html
@@ -154,14 +154,17 @@
       </ul>
     </div>
 
+    <div class="grid-zoom-panel" aria-label="Tile zoom control">
+      <div class="grid-zoom-control">
+        <span class="zoom-symbol" aria-hidden="true">−</span>
+        <input type="range" id="gridZoomSlider" min="0" max="3" step="1" value="1" />
+        <span class="zoom-symbol" aria-hidden="true">+</span>
+      </div>
+      <p id="gridZoomValue" class="grid-zoom-value">103.3%</p>
+    </div>
+
     <div class="hover-trigger">
       <div class="pinned">
-          <div class="grid-zoom-control" aria-label="Tile zoom control">
-            <span class="zoom-symbol" aria-hidden="true">−</span>
-            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
-            <span class="zoom-symbol" aria-hidden="true">+</span>
-          </div>
-          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -322,10 +325,30 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      let currentGridScale = 100;
+      const GRID_ZOOM_LEVELS = [80, 103.3, 126.7, 150];
+      let currentGridScale = GRID_ZOOM_LEVELS[1];
+
+      function findClosestGridZoomIndex(value) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+          return 1;
+        }
+
+        let closestIndex = 0;
+        let closestDistance = Infinity;
+        GRID_ZOOM_LEVELS.forEach((zoomLevel, index) => {
+          const distance = Math.abs(zoomLevel - numericValue);
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = index;
+          }
+        });
+        return closestIndex;
+      }
 
       function applyGridScale(value, persist = true) {
-        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        const numericValue = Number(value);
+        const clampedValue = Math.min(150, Math.max(80, Number.isFinite(numericValue) ? numericValue : GRID_ZOOM_LEVELS[1]));
         currentGridScale = clampedValue;
         const scaleFactor = clampedValue / 100;
         document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
@@ -333,14 +356,14 @@
         const gridZoomSlider = document.getElementById("gridZoomSlider");
         const gridZoomValue = document.getElementById("gridZoomValue");
         if (gridZoomSlider) {
-          gridZoomSlider.value = clampedValue.toFixed(1);
+          gridZoomSlider.value = String(findClosestGridZoomIndex(clampedValue));
         }
         if (gridZoomValue) {
-          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+          gridZoomValue.textContent = `${clampedValue.toFixed(1)}%`;
         }
 
         if (persist) {
-          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toFixed(1));
         }
       }
 
@@ -350,11 +373,14 @@
           return;
         }
 
-        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
-        applyGridScale(savedValue, false);
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`));
+        const initialValue = Number.isFinite(savedValue) ? Math.min(150, Math.max(80, savedValue)) : GRID_ZOOM_LEVELS[1];
+        applyGridScale(initialValue, false);
 
         gridZoomSlider.addEventListener("input", (event) => {
-          applyGridScale(event.target.value);
+          const zoomIndex = Number(event.target.value);
+          const zoomValue = GRID_ZOOM_LEVELS[zoomIndex] ?? GRID_ZOOM_LEVELS[1];
+          applyGridScale(zoomValue);
         });
       }
 
@@ -668,11 +694,33 @@ function initializeDragAndDrop() {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
             event.dataTransfer.effectAllowed = 'move';
+
+            let dragPreview = null;
+            if (!isMobileViewport()) {
+                dragPreview = card.cloneNode(true);
+                dragPreview.classList.add('drag-preview');
+                dragPreview.style.position = 'fixed';
+                dragPreview.style.top = '-9999px';
+                dragPreview.style.left = '-9999px';
+                dragPreview.style.width = `${card.offsetWidth}px`;
+                dragPreview.style.pointerEvents = 'none';
+                dragPreview.style.transform = 'scale(0.6)';
+                dragPreview.style.transformOrigin = 'top left';
+                dragPreview.style.zIndex = '9999';
+                document.body.appendChild(dragPreview);
+                event.dataTransfer.setDragImage(dragPreview, 20, 20);
+            }
+
+            card._dragPreview = dragPreview;
             card.classList.add('dragging');
             document.body.classList.add('is-dragging-item');
         });
 
         card.addEventListener('dragend', () => {
+            if (card._dragPreview) {
+                card._dragPreview.remove();
+                card._dragPreview = null;
+            }
             card.classList.remove('dragging');
             document.body.classList.remove('is-dragging-item');
             clearDropTargets();

--- a/bloodborne.html
+++ b/bloodborne.html
@@ -3,11 +3,13 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Up your Hunter's style with souls.fashion, the tool for finding color-matching attire and weapons in Bloodborne. Create a striking look as you explore Yharnam and face the nightmarish beasts in fashion.">
 		<meta property="og:site_name" content="Bloodborne - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -16,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Bloodborne - Fashion Souls v1.0.8</title>
+    <title>Bloodborne - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -86,7 +91,7 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -151,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -180,7 +191,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "bloodborne_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -188,64 +199,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -324,36 +322,95 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      let currentGridScale = 100;
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
         }
-      });
-
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
         }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
 
-      window.addEventListener("scroll", () => {
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
+          return;
+        }
+
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
+
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
+        };
+
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
+
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
+      }
+
+
+      function updateScrollUI() {
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
+
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +419,40 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const atTop = scrollY <= 4;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -435,6 +508,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -579,6 +653,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +667,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +702,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +747,9 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };
@@ -678,20 +770,29 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
     });
 });
-
-window.onresize = adjustPinnedStyles;
-
-
   </script>
-  
     <script>
-    window.addEventListener("load", () => {
+    (function setupPreloader() {
         const preloader = document.getElementById("preloader");
-        preloader.style.opacity = "0"; // Fade out effect
-        setTimeout(() => {
-            preloader.style.display = "none"; // Completely hide after fading
-        }, 1000); // Duration of fade effect in milliseconds
-    });
+        if (!preloader) {
+            return;
+        }
+
+        let hidden = false;
+        const hidePreloader = () => {
+            if (hidden) return;
+            hidden = true;
+            preloader.classList.add("hidden");
+            setTimeout(() => {
+                preloader.style.display = "none";
+            }, 650);
+        };
+
+        window.addEventListener("initial-grid-images-loaded", hidePreloader, { once: true });
+        window.addEventListener("load", () => {
+            setTimeout(hidePreloader, 2600);
+        }, { once: true });
+    })();
 </script>
   
   </body>

--- a/demonssouls.html
+++ b/demonssouls.html
@@ -3,14 +3,13 @@
   <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="description" content="Design perfect color-matching outfits in Elden Ring with souls.fashion. Explore coordinated armor sets, weapons, and accessories for a unique style that suits your Tarnished – the ultimate Elden Ring fashion tool!">
 		<meta property="og:site_name" content="Elden Ring - Fashion Souls" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Spectral"
-    />
-    <link rel="stylesheet" href="resources/styles.css?v1.0.5" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap" />
+    <link rel="stylesheet" href="resources/styles.css?v1.0.9" />
     <link rel="icon" type="image/x-icon" href="icon.ico" />
     <link
       rel="apple-touch-icon"
@@ -42,7 +41,7 @@
       sizes="96x96"
       href="favicons/icon_96x96.png"
     />
-    <title>Demon's Souls - Fashion Souls v1.0.8</title>
+    <title>Demon's Souls - Fashion Souls v1.0.9</title>
   </head>
   <body>
   <div id="preloader" class="preloader">
@@ -52,7 +51,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -112,7 +114,7 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -177,6 +179,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -207,7 +215,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "eldenring_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -215,64 +223,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -351,36 +346,95 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      let currentGridScale = 100;
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
         }
-      });
-
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
         }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
 
-      window.addEventListener("scroll", () => {
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
+          return;
+        }
+
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
+
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
+        };
+
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
+
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
+      }
+
+
+      function updateScrollUI() {
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
+
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -389,24 +443,40 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const atTop = scrollY <= 4;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -462,6 +532,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -608,6 +679,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -617,16 +693,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -635,33 +728,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -687,6 +773,9 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };
@@ -707,21 +796,29 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
     });
 });
-
-
-window.onresize = adjustPinnedStyles;
-
-
   </script>
-  
-  <script>
-    window.addEventListener("load", () => {
+    <script>
+    (function setupPreloader() {
         const preloader = document.getElementById("preloader");
-        preloader.style.opacity = "0"; // Fade out effect
-        setTimeout(() => {
-            preloader.style.display = "none"; // Completely hide after fading
-        }, 3000); // Duration of fade effect in milliseconds
-    });
+        if (!preloader) {
+            return;
+        }
+
+        let hidden = false;
+        const hidePreloader = () => {
+            if (hidden) return;
+            hidden = true;
+            preloader.classList.add("hidden");
+            setTimeout(() => {
+                preloader.style.display = "none";
+            }, 650);
+        };
+
+        window.addEventListener("initial-grid-images-loaded", hidePreloader, { once: true });
+        window.addEventListener("load", () => {
+            setTimeout(hidePreloader, 2600);
+        }, { once: true });
+    })();
 </script>
   
   </body>

--- a/demonssouls.html
+++ b/demonssouls.html
@@ -177,14 +177,17 @@
       </ul>
     </div>
 
+    <div class="grid-zoom-panel" aria-label="Tile zoom control">
+      <div class="grid-zoom-control">
+        <span class="zoom-symbol" aria-hidden="true">−</span>
+        <input type="range" id="gridZoomSlider" min="0" max="3" step="1" value="1" />
+        <span class="zoom-symbol" aria-hidden="true">+</span>
+      </div>
+      <p id="gridZoomValue" class="grid-zoom-value">103.3%</p>
+    </div>
+
     <div class="hover-trigger">
       <div class="pinned">
-          <div class="grid-zoom-control" aria-label="Tile zoom control">
-            <span class="zoom-symbol" aria-hidden="true">−</span>
-            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
-            <span class="zoom-symbol" aria-hidden="true">+</span>
-          </div>
-          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -346,10 +349,30 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      let currentGridScale = 100;
+      const GRID_ZOOM_LEVELS = [80, 103.3, 126.7, 150];
+      let currentGridScale = GRID_ZOOM_LEVELS[1];
+
+      function findClosestGridZoomIndex(value) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+          return 1;
+        }
+
+        let closestIndex = 0;
+        let closestDistance = Infinity;
+        GRID_ZOOM_LEVELS.forEach((zoomLevel, index) => {
+          const distance = Math.abs(zoomLevel - numericValue);
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = index;
+          }
+        });
+        return closestIndex;
+      }
 
       function applyGridScale(value, persist = true) {
-        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        const numericValue = Number(value);
+        const clampedValue = Math.min(150, Math.max(80, Number.isFinite(numericValue) ? numericValue : GRID_ZOOM_LEVELS[1]));
         currentGridScale = clampedValue;
         const scaleFactor = clampedValue / 100;
         document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
@@ -357,14 +380,14 @@
         const gridZoomSlider = document.getElementById("gridZoomSlider");
         const gridZoomValue = document.getElementById("gridZoomValue");
         if (gridZoomSlider) {
-          gridZoomSlider.value = clampedValue.toFixed(1);
+          gridZoomSlider.value = String(findClosestGridZoomIndex(clampedValue));
         }
         if (gridZoomValue) {
-          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+          gridZoomValue.textContent = `${clampedValue.toFixed(1)}%`;
         }
 
         if (persist) {
-          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toFixed(1));
         }
       }
 
@@ -374,11 +397,14 @@
           return;
         }
 
-        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
-        applyGridScale(savedValue, false);
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`));
+        const initialValue = Number.isFinite(savedValue) ? Math.min(150, Math.max(80, savedValue)) : GRID_ZOOM_LEVELS[1];
+        applyGridScale(initialValue, false);
 
         gridZoomSlider.addEventListener("input", (event) => {
-          applyGridScale(event.target.value);
+          const zoomIndex = Number(event.target.value);
+          const zoomValue = GRID_ZOOM_LEVELS[zoomIndex] ?? GRID_ZOOM_LEVELS[1];
+          applyGridScale(zoomValue);
         });
       }
 
@@ -694,11 +720,33 @@ function initializeDragAndDrop() {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
             event.dataTransfer.effectAllowed = 'move';
+
+            let dragPreview = null;
+            if (!isMobileViewport()) {
+                dragPreview = card.cloneNode(true);
+                dragPreview.classList.add('drag-preview');
+                dragPreview.style.position = 'fixed';
+                dragPreview.style.top = '-9999px';
+                dragPreview.style.left = '-9999px';
+                dragPreview.style.width = `${card.offsetWidth}px`;
+                dragPreview.style.pointerEvents = 'none';
+                dragPreview.style.transform = 'scale(0.6)';
+                dragPreview.style.transformOrigin = 'top left';
+                dragPreview.style.zIndex = '9999';
+                document.body.appendChild(dragPreview);
+                event.dataTransfer.setDragImage(dragPreview, 20, 20);
+            }
+
+            card._dragPreview = dragPreview;
             card.classList.add('dragging');
             document.body.classList.add('is-dragging-item');
         });
 
         card.addEventListener('dragend', () => {
+            if (card._dragPreview) {
+                card._dragPreview.remove();
+                card._dragPreview = null;
+            }
             card.classList.remove('dragging');
             document.body.classList.remove('is-dragging-item');
             clearDropTargets();

--- a/ds1.html
+++ b/ds1.html
@@ -154,14 +154,17 @@
       </ul>
     </div>
 
+    <div class="grid-zoom-panel" aria-label="Tile zoom control">
+      <div class="grid-zoom-control">
+        <span class="zoom-symbol" aria-hidden="true">−</span>
+        <input type="range" id="gridZoomSlider" min="0" max="3" step="1" value="1" />
+        <span class="zoom-symbol" aria-hidden="true">+</span>
+      </div>
+      <p id="gridZoomValue" class="grid-zoom-value">103.3%</p>
+    </div>
+
     <div class="hover-trigger">
       <div class="pinned">
-          <div class="grid-zoom-control" aria-label="Tile zoom control">
-            <span class="zoom-symbol" aria-hidden="true">−</span>
-            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
-            <span class="zoom-symbol" aria-hidden="true">+</span>
-          </div>
-          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -322,10 +325,30 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      let currentGridScale = 100;
+      const GRID_ZOOM_LEVELS = [80, 103.3, 126.7, 150];
+      let currentGridScale = GRID_ZOOM_LEVELS[1];
+
+      function findClosestGridZoomIndex(value) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+          return 1;
+        }
+
+        let closestIndex = 0;
+        let closestDistance = Infinity;
+        GRID_ZOOM_LEVELS.forEach((zoomLevel, index) => {
+          const distance = Math.abs(zoomLevel - numericValue);
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = index;
+          }
+        });
+        return closestIndex;
+      }
 
       function applyGridScale(value, persist = true) {
-        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        const numericValue = Number(value);
+        const clampedValue = Math.min(150, Math.max(80, Number.isFinite(numericValue) ? numericValue : GRID_ZOOM_LEVELS[1]));
         currentGridScale = clampedValue;
         const scaleFactor = clampedValue / 100;
         document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
@@ -333,14 +356,14 @@
         const gridZoomSlider = document.getElementById("gridZoomSlider");
         const gridZoomValue = document.getElementById("gridZoomValue");
         if (gridZoomSlider) {
-          gridZoomSlider.value = clampedValue.toFixed(1);
+          gridZoomSlider.value = String(findClosestGridZoomIndex(clampedValue));
         }
         if (gridZoomValue) {
-          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+          gridZoomValue.textContent = `${clampedValue.toFixed(1)}%`;
         }
 
         if (persist) {
-          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toFixed(1));
         }
       }
 
@@ -350,11 +373,14 @@
           return;
         }
 
-        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
-        applyGridScale(savedValue, false);
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`));
+        const initialValue = Number.isFinite(savedValue) ? Math.min(150, Math.max(80, savedValue)) : GRID_ZOOM_LEVELS[1];
+        applyGridScale(initialValue, false);
 
         gridZoomSlider.addEventListener("input", (event) => {
-          applyGridScale(event.target.value);
+          const zoomIndex = Number(event.target.value);
+          const zoomValue = GRID_ZOOM_LEVELS[zoomIndex] ?? GRID_ZOOM_LEVELS[1];
+          applyGridScale(zoomValue);
         });
       }
 
@@ -668,11 +694,33 @@ function initializeDragAndDrop() {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
             event.dataTransfer.effectAllowed = 'move';
+
+            let dragPreview = null;
+            if (!isMobileViewport()) {
+                dragPreview = card.cloneNode(true);
+                dragPreview.classList.add('drag-preview');
+                dragPreview.style.position = 'fixed';
+                dragPreview.style.top = '-9999px';
+                dragPreview.style.left = '-9999px';
+                dragPreview.style.width = `${card.offsetWidth}px`;
+                dragPreview.style.pointerEvents = 'none';
+                dragPreview.style.transform = 'scale(0.6)';
+                dragPreview.style.transformOrigin = 'top left';
+                dragPreview.style.zIndex = '9999';
+                document.body.appendChild(dragPreview);
+                event.dataTransfer.setDragImage(dragPreview, 20, 20);
+            }
+
+            card._dragPreview = dragPreview;
             card.classList.add('dragging');
             document.body.classList.add('is-dragging-item');
         });
 
         card.addEventListener('dragend', () => {
+            if (card._dragPreview) {
+                card._dragPreview.remove();
+                card._dragPreview = null;
+            }
             card.classList.remove('dragging');
             document.body.classList.remove('is-dragging-item');
             clearDropTargets();

--- a/ds1.html
+++ b/ds1.html
@@ -3,11 +3,13 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Style your Undead in Dark Souls Remastered & Prepare to Die Edition with souls.fashion, the tool for finding color-coordinated armor and weapons. Create iconic looks as you journey through Lordran with gear that stands out.">
 		<meta property="og:site_name" content="Dark Souls - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -16,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Dark Souls - Fashion Souls v1.0.8</title>
+    <title>Dark Souls - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -86,7 +91,7 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -151,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -180,7 +191,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.9"></script>
    <script>
 	const gamePrefix = "ds1_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -189,63 +200,50 @@
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
       
+      const nav = document.querySelector('.navigation');
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -324,36 +322,95 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      let currentGridScale = 100;
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
         }
-      });
-
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
         }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
 
-      window.addEventListener("scroll", () => {
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
+          return;
+        }
+
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
+
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
+        };
+
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
+
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
+      }
+
+
+      function updateScrollUI() {
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
+
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +419,40 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const atTop = scrollY <= 4;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -435,6 +508,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -579,6 +653,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +667,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +702,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +747,9 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };
@@ -679,18 +771,29 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
-window.onresize = adjustPinnedStyles;
-
-
   </script>
     <script>
-    window.addEventListener("load", () => {
+    (function setupPreloader() {
         const preloader = document.getElementById("preloader");
-        preloader.style.opacity = "0"; // Fade out effect
-        setTimeout(() => {
-            preloader.style.display = "none"; // Completely hide after fading
-        }, 1000); // Duration of fade effect in milliseconds
-    });
+        if (!preloader) {
+            return;
+        }
+
+        let hidden = false;
+        const hidePreloader = () => {
+            if (hidden) return;
+            hidden = true;
+            preloader.classList.add("hidden");
+            setTimeout(() => {
+                preloader.style.display = "none";
+            }, 650);
+        };
+
+        window.addEventListener("initial-grid-images-loaded", hidePreloader, { once: true });
+        window.addEventListener("load", () => {
+            setTimeout(hidePreloader, 2600);
+        }, { once: true });
+    })();
 </script>
   
   </body>

--- a/ds2.html
+++ b/ds2.html
@@ -154,14 +154,17 @@
       </ul>
     </div>
 
+    <div class="grid-zoom-panel" aria-label="Tile zoom control">
+      <div class="grid-zoom-control">
+        <span class="zoom-symbol" aria-hidden="true">−</span>
+        <input type="range" id="gridZoomSlider" min="0" max="3" step="1" value="1" />
+        <span class="zoom-symbol" aria-hidden="true">+</span>
+      </div>
+      <p id="gridZoomValue" class="grid-zoom-value">103.3%</p>
+    </div>
+
     <div class="hover-trigger">
       <div class="pinned">
-          <div class="grid-zoom-control" aria-label="Tile zoom control">
-            <span class="zoom-symbol" aria-hidden="true">−</span>
-            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
-            <span class="zoom-symbol" aria-hidden="true">+</span>
-          </div>
-          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -322,10 +325,30 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      let currentGridScale = 100;
+      const GRID_ZOOM_LEVELS = [80, 103.3, 126.7, 150];
+      let currentGridScale = GRID_ZOOM_LEVELS[1];
+
+      function findClosestGridZoomIndex(value) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+          return 1;
+        }
+
+        let closestIndex = 0;
+        let closestDistance = Infinity;
+        GRID_ZOOM_LEVELS.forEach((zoomLevel, index) => {
+          const distance = Math.abs(zoomLevel - numericValue);
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = index;
+          }
+        });
+        return closestIndex;
+      }
 
       function applyGridScale(value, persist = true) {
-        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        const numericValue = Number(value);
+        const clampedValue = Math.min(150, Math.max(80, Number.isFinite(numericValue) ? numericValue : GRID_ZOOM_LEVELS[1]));
         currentGridScale = clampedValue;
         const scaleFactor = clampedValue / 100;
         document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
@@ -333,14 +356,14 @@
         const gridZoomSlider = document.getElementById("gridZoomSlider");
         const gridZoomValue = document.getElementById("gridZoomValue");
         if (gridZoomSlider) {
-          gridZoomSlider.value = clampedValue.toFixed(1);
+          gridZoomSlider.value = String(findClosestGridZoomIndex(clampedValue));
         }
         if (gridZoomValue) {
-          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+          gridZoomValue.textContent = `${clampedValue.toFixed(1)}%`;
         }
 
         if (persist) {
-          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toFixed(1));
         }
       }
 
@@ -350,11 +373,14 @@
           return;
         }
 
-        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
-        applyGridScale(savedValue, false);
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`));
+        const initialValue = Number.isFinite(savedValue) ? Math.min(150, Math.max(80, savedValue)) : GRID_ZOOM_LEVELS[1];
+        applyGridScale(initialValue, false);
 
         gridZoomSlider.addEventListener("input", (event) => {
-          applyGridScale(event.target.value);
+          const zoomIndex = Number(event.target.value);
+          const zoomValue = GRID_ZOOM_LEVELS[zoomIndex] ?? GRID_ZOOM_LEVELS[1];
+          applyGridScale(zoomValue);
         });
       }
 
@@ -668,11 +694,33 @@ function initializeDragAndDrop() {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
             event.dataTransfer.effectAllowed = 'move';
+
+            let dragPreview = null;
+            if (!isMobileViewport()) {
+                dragPreview = card.cloneNode(true);
+                dragPreview.classList.add('drag-preview');
+                dragPreview.style.position = 'fixed';
+                dragPreview.style.top = '-9999px';
+                dragPreview.style.left = '-9999px';
+                dragPreview.style.width = `${card.offsetWidth}px`;
+                dragPreview.style.pointerEvents = 'none';
+                dragPreview.style.transform = 'scale(0.6)';
+                dragPreview.style.transformOrigin = 'top left';
+                dragPreview.style.zIndex = '9999';
+                document.body.appendChild(dragPreview);
+                event.dataTransfer.setDragImage(dragPreview, 20, 20);
+            }
+
+            card._dragPreview = dragPreview;
             card.classList.add('dragging');
             document.body.classList.add('is-dragging-item');
         });
 
         card.addEventListener('dragend', () => {
+            if (card._dragPreview) {
+                card._dragPreview.remove();
+                card._dragPreview = null;
+            }
             card.classList.remove('dragging');
             document.body.classList.remove('is-dragging-item');
             clearDropTargets();

--- a/ds2.html
+++ b/ds2.html
@@ -3,11 +3,13 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Transform your journey in Dark Souls 2 with souls.fashion, the ultimate Dark Souls II fashion tool. Find matching armor and weapons to create a distinct look for your character as you explore the kingdom of Drangleic.">
 		<meta property="og:site_name" content="Dark Souls II - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -16,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Dark Souls II - Fashion Souls v1.0.8</title>
+    <title>Dark Souls II - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -86,7 +91,7 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -151,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -180,7 +191,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "ds2_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -188,64 +199,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -324,36 +322,95 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      let currentGridScale = 100;
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
         }
-      });
-
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
         }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
 
-      window.addEventListener("scroll", () => {
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
+          return;
+        }
+
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
+
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
+        };
+
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
+
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
+      }
+
+
+      function updateScrollUI() {
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
+
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +419,40 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const atTop = scrollY <= 4;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -435,6 +508,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -579,6 +653,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +667,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +702,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +747,9 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };
@@ -679,18 +771,30 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
-window.onresize = adjustPinnedStyles;
-
 
   </script>
     <script>
-    window.addEventListener("load", () => {
+    (function setupPreloader() {
         const preloader = document.getElementById("preloader");
-        preloader.style.opacity = "0"; // Fade out effect
-        setTimeout(() => {
-            preloader.style.display = "none"; // Completely hide after fading
-        }, 1000); // Duration of fade effect in milliseconds
-    });
+        if (!preloader) {
+            return;
+        }
+
+        let hidden = false;
+        const hidePreloader = () => {
+            if (hidden) return;
+            hidden = true;
+            preloader.classList.add("hidden");
+            setTimeout(() => {
+                preloader.style.display = "none";
+            }, 650);
+        };
+
+        window.addEventListener("initial-grid-images-loaded", hidePreloader, { once: true });
+        window.addEventListener("load", () => {
+            setTimeout(hidePreloader, 2600);
+        }, { once: true });
+    })();
 </script>
   </body>
 </html>

--- a/ds3.html
+++ b/ds3.html
@@ -154,14 +154,17 @@
       </ul>
     </div>
 
+    <div class="grid-zoom-panel" aria-label="Tile zoom control">
+      <div class="grid-zoom-control">
+        <span class="zoom-symbol" aria-hidden="true">−</span>
+        <input type="range" id="gridZoomSlider" min="0" max="3" step="1" value="1" />
+        <span class="zoom-symbol" aria-hidden="true">+</span>
+      </div>
+      <p id="gridZoomValue" class="grid-zoom-value">103.3%</p>
+    </div>
+
     <div class="hover-trigger">
       <div class="pinned">
-          <div class="grid-zoom-control" aria-label="Tile zoom control">
-            <span class="zoom-symbol" aria-hidden="true">−</span>
-            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
-            <span class="zoom-symbol" aria-hidden="true">+</span>
-          </div>
-          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -322,10 +325,30 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      let currentGridScale = 100;
+      const GRID_ZOOM_LEVELS = [80, 103.3, 126.7, 150];
+      let currentGridScale = GRID_ZOOM_LEVELS[1];
+
+      function findClosestGridZoomIndex(value) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+          return 1;
+        }
+
+        let closestIndex = 0;
+        let closestDistance = Infinity;
+        GRID_ZOOM_LEVELS.forEach((zoomLevel, index) => {
+          const distance = Math.abs(zoomLevel - numericValue);
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = index;
+          }
+        });
+        return closestIndex;
+      }
 
       function applyGridScale(value, persist = true) {
-        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        const numericValue = Number(value);
+        const clampedValue = Math.min(150, Math.max(80, Number.isFinite(numericValue) ? numericValue : GRID_ZOOM_LEVELS[1]));
         currentGridScale = clampedValue;
         const scaleFactor = clampedValue / 100;
         document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
@@ -333,14 +356,14 @@
         const gridZoomSlider = document.getElementById("gridZoomSlider");
         const gridZoomValue = document.getElementById("gridZoomValue");
         if (gridZoomSlider) {
-          gridZoomSlider.value = clampedValue.toFixed(1);
+          gridZoomSlider.value = String(findClosestGridZoomIndex(clampedValue));
         }
         if (gridZoomValue) {
-          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+          gridZoomValue.textContent = `${clampedValue.toFixed(1)}%`;
         }
 
         if (persist) {
-          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toFixed(1));
         }
       }
 
@@ -350,11 +373,14 @@
           return;
         }
 
-        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
-        applyGridScale(savedValue, false);
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`));
+        const initialValue = Number.isFinite(savedValue) ? Math.min(150, Math.max(80, savedValue)) : GRID_ZOOM_LEVELS[1];
+        applyGridScale(initialValue, false);
 
         gridZoomSlider.addEventListener("input", (event) => {
-          applyGridScale(event.target.value);
+          const zoomIndex = Number(event.target.value);
+          const zoomValue = GRID_ZOOM_LEVELS[zoomIndex] ?? GRID_ZOOM_LEVELS[1];
+          applyGridScale(zoomValue);
         });
       }
 
@@ -668,11 +694,33 @@ function initializeDragAndDrop() {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
             event.dataTransfer.effectAllowed = 'move';
+
+            let dragPreview = null;
+            if (!isMobileViewport()) {
+                dragPreview = card.cloneNode(true);
+                dragPreview.classList.add('drag-preview');
+                dragPreview.style.position = 'fixed';
+                dragPreview.style.top = '-9999px';
+                dragPreview.style.left = '-9999px';
+                dragPreview.style.width = `${card.offsetWidth}px`;
+                dragPreview.style.pointerEvents = 'none';
+                dragPreview.style.transform = 'scale(0.6)';
+                dragPreview.style.transformOrigin = 'top left';
+                dragPreview.style.zIndex = '9999';
+                document.body.appendChild(dragPreview);
+                event.dataTransfer.setDragImage(dragPreview, 20, 20);
+            }
+
+            card._dragPreview = dragPreview;
             card.classList.add('dragging');
             document.body.classList.add('is-dragging-item');
         });
 
         card.addEventListener('dragend', () => {
+            if (card._dragPreview) {
+                card._dragPreview.remove();
+                card._dragPreview = null;
+            }
             card.classList.remove('dragging');
             document.body.classList.remove('is-dragging-item');
             clearDropTargets();

--- a/ds3.html
+++ b/ds3.html
@@ -3,11 +3,13 @@
 <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<meta name="description" content="Unleash your Ashen One’s true colors in Dark Souls 3 with souls.fashion. This tool helps you discover coordinated armor sets and weapons, creating unforgettable looks for your journey through Lothric.">
 		<meta property="og:site_name" content="Dark Souls III - Fashion Souls" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -16,7 +18,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Dark Souls III - Fashion Souls v1.0.8</title>
+    <title>Dark Souls III - Fashion Souls v1.0.9</title>
     
 </head>
   <body>
@@ -27,7 +29,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -86,7 +91,7 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -151,6 +156,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -180,7 +191,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "ds3_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -188,64 +199,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -324,36 +322,95 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      let currentGridScale = 100;
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
         }
-      });
-
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
         }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
 
-      window.addEventListener("scroll", () => {
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
+          return;
+        }
+
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
+
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
+        };
+
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
+
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
+      }
+
+
+      function updateScrollUI() {
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
+
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -362,24 +419,40 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const atTop = scrollY <= 4;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -435,6 +508,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -579,6 +653,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -588,16 +667,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -606,33 +702,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -658,6 +747,9 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };
@@ -679,18 +771,30 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 });
 
-window.onresize = adjustPinnedStyles;
-
 
   </script>
     <script>
-    window.addEventListener("load", () => {
+    (function setupPreloader() {
         const preloader = document.getElementById("preloader");
-        preloader.style.opacity = "0"; // Fade out effect
-        setTimeout(() => {
-            preloader.style.display = "none"; // Completely hide after fading
-        }, 1000); // Duration of fade effect in milliseconds
-    });
+        if (!preloader) {
+            return;
+        }
+
+        let hidden = false;
+        const hidePreloader = () => {
+            if (hidden) return;
+            hidden = true;
+            preloader.classList.add("hidden");
+            setTimeout(() => {
+                preloader.style.display = "none";
+            }, 650);
+        };
+
+        window.addEventListener("initial-grid-images-loaded", hidePreloader, { once: true });
+        window.addEventListener("load", () => {
+            setTimeout(hidePreloader, 2600);
+        }, { once: true });
+    })();
 </script>
   </body>
 </html>

--- a/eldenring.html
+++ b/eldenring.html
@@ -3,14 +3,13 @@
   <head>
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="description" content="Design perfect color-matching outfits in Elden Ring with souls.fashion. Explore coordinated armor sets, weapons, and accessories for a unique style that suits your Tarnished – the ultimate Elden Ring fashion tool!">
 		<meta property="og:site_name" content="Elden Ring - Fashion Souls" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Spectral"
-    />
-    <link rel="stylesheet" href="resources/styles.css?v1.0.5" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap" />
+    <link rel="stylesheet" href="resources/styles.css?v1.0.9" />
     <link rel="icon" type="image/x-icon" href="icon.ico" />
     <link
       rel="apple-touch-icon"
@@ -42,7 +41,7 @@
       sizes="96x96"
       href="favicons/icon_96x96.png"
     />
-    <title>Elden Ring - Fashion Souls v1.0.8</title>
+    <title>Elden Ring - Fashion Souls v1.0.9</title>
   </head>
   <body>
   <div id="preloader" class="preloader">
@@ -52,7 +51,10 @@
   <div id="fullScreenNotice" class="full-screen-notice">
     <div class="notice-content">
         <p>
-            NOTICE: If the site layout looks strange or images are not loading, please press <strong>ctrl+F5</strong> to re-cache your browser. Alternatively, delete your browser's cache manually and the site should work as expected.
+            Fashion Souls is an open-source community project - if you'd like to encourage its ongoing existence, please consider <a href="https://ko-fi.com/psyopgirl" target="_blank" rel="noopener noreferrer">supporting us</a>!
+        </p>
+        <p>
+            If the site looks strange or doesn't load, press <strong>ctrl + F5</strong> to re-cache your browser. Alternatively, delete your cache manually.
         </p>
         <p><span id="dismissNotice" style="color: #ffeb3b; cursor: pointer; text-decoration: underline;">Click here to dismiss this message</span></p>
     </div>
@@ -112,7 +114,7 @@
         <button id="legsFilter">Legs</button>
         <button id="weaponsFilter">Weapons</button>
         <button id="shieldsFilter">Shields</button>
-        <button id="clearFilter">Clear Filters</button>
+                <button id="clearFilter">Clear Filters</button>
         <div class="sliders">
           <div class="slider-container">
             <label for="secondaryWeightSlider">
@@ -177,6 +179,12 @@
 
     <div class="hover-trigger">
       <div class="pinned">
+          <div class="grid-zoom-control" aria-label="Tile zoom control">
+            <span class="zoom-symbol" aria-hidden="true">−</span>
+            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
+            <span class="zoom-symbol" aria-hidden="true">+</span>
+          </div>
+          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -207,7 +215,7 @@
       <button class="back-to-top-button">Back to Top</button>
     </footer>
 
-    <script src="search_items.js?v1.0.5"></script>
+    <script src="search_items.js?v1.0.9"></script>
     <script>
 	const gamePrefix = "eldenring_"; // Unique prefix for LocalStorage handling
       const modeToggle = document.getElementById("modeToggle");
@@ -215,64 +223,51 @@
       const toggleSearch = document.getElementById("toggleSearch");
       const colorPicker = document.getElementById("favcolor");
       const searchInput = document.getElementById("searchInput");
+      const nav = document.querySelector('.navigation');
       
       let navActive = true;
-      let lastTouchY = 0;
       let sidebarActive = false;
+      let scrollRafId = null;
+
+      function isMobileViewport() {
+        return window.matchMedia("(max-width: 1199px)").matches;
+      }
+
+      function setMobileSidebarVisible(visible) {
+        if (!isMobileViewport()) {
+          body.classList.remove("mobile-sidebar-visible");
+          sidebarActive = false;
+          navActive = true;
+          return;
+        }
+
+        body.classList.toggle("mobile-sidebar-visible", visible);
+        sidebarActive = visible;
+        navActive = !visible;
+      }
 
       function showOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "1";
-          document.querySelector(".pinned").style.display = "block";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "0";
-          document.querySelector(".item-grid").style.marginLeft = "8rem";
-          
-          sidebarActive = true;
-          navActive = false;
-        }
+        setMobileSidebarVisible(true);
       }
 
       function hideOutfitSidebar() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          document.querySelector(".pinned").style.opacity = "0";
-          document.querySelector(".pinned").style.display = "none";
-
-          // Set margin based on mobile screen
-          document.querySelector(".item-grid").style.marginTop = "180px";
-          document.querySelector(".item-grid").style.marginLeft = "0";
-          
-          
-          sidebarActive = false;
-          navActive = true;
-        }
+        setMobileSidebarVisible(false);
       }
 
       function showNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === false) {
-            nav.classList.remove('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "0px";
-            sidebarActive = false;
-            navActive = true;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.remove('hidden-on-scroll');
       }
 
       function hideNav() {
-        if (window.matchMedia("(min-width: 0px) and (max-width: 1199px)").matches) {
-          if (sidebarActive === true) {
-            nav.classList.add('hidden-on-scroll');
-
-            document.querySelector(".item-grid").style.marginTop = "0";
-            document.querySelector(".item-grid").style.marginLeft = "70px";
-            sidebarActive = true;
-            navActive = false;
-          }
+        if (isMobileViewport()) {
+          return;
         }
+
+        nav.classList.add('hidden-on-scroll');
       }
 
 
@@ -351,36 +346,95 @@
         window.location.href = `simulator_${page}.html`;
       });
 
+      let currentGridScale = 100;
 
-      // Activate effect on scroll attempt (downward or upward for wheel)
-      window.addEventListener("wheel", (event) => {
-        if (event.deltaY > 0 && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-          hideNav();
-        } else if (event.deltaY < 0 && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
-          showNav();
+      function applyGridScale(value, persist = true) {
+        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        currentGridScale = clampedValue;
+        const scaleFactor = clampedValue / 100;
+        document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
+
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        const gridZoomValue = document.getElementById("gridZoomValue");
+        if (gridZoomSlider) {
+          gridZoomSlider.value = clampedValue.toFixed(1);
         }
-      });
-
-      // Activate effect on touch devices
-      window.addEventListener("touchstart", (event) => {
-        lastTouchY = event.touches[0].clientY; // Track initial touch position
-      });
-      
-      window.addEventListener("touchmove", (event) => {
-        const currentTouchY = event.touches[0].clientY;
-        if (currentTouchY < lastTouchY && !sidebarActive) {
-          showOutfitSidebar(); // Scrolling down
-        } else if (currentTouchY > lastTouchY && sidebarActive) {
-          hideOutfitSidebar(); // Scrolling up
+        if (gridZoomValue) {
+          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
         }
-        lastTouchY = currentTouchY; // Update last touch position
-      });
 
-      window.addEventListener("scroll", () => {
+        if (persist) {
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+        }
+      }
+
+      function initGridZoomControl() {
+        const gridZoomSlider = document.getElementById("gridZoomSlider");
+        if (!gridZoomSlider) {
+          return;
+        }
+
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
+        applyGridScale(savedValue, false);
+
+        gridZoomSlider.addEventListener("input", (event) => {
+          applyGridScale(event.target.value);
+        });
+      }
+
+      function setupPinchZoom() {
+        const itemGridElement = document.getElementById("itemGrid");
+        if (!itemGridElement) {
+          return;
+        }
+
+        let pinchStartDistance = null;
+        let pinchStartScale = currentGridScale;
+
+        const getDistance = (touchA, touchB) => {
+          const dx = touchA.clientX - touchB.clientX;
+          const dy = touchA.clientY - touchB.clientY;
+          return Math.hypot(dx, dy);
+        };
+
+        const onTouchStart = (event) => {
+          if (!isMobileViewport() || event.touches.length !== 2) {
+            return;
+          }
+
+          pinchStartDistance = getDistance(event.touches[0], event.touches[1]);
+          pinchStartScale = currentGridScale;
+          event.preventDefault();
+        };
+
+        const onTouchMove = (event) => {
+          if (!isMobileViewport() || pinchStartDistance === null || event.touches.length !== 2) {
+            return;
+          }
+
+          const currentDistance = getDistance(event.touches[0], event.touches[1]);
+          const zoomRatio = currentDistance / pinchStartDistance;
+          applyGridScale(pinchStartScale * zoomRatio);
+          event.preventDefault();
+        };
+
+        const onTouchEnd = (event) => {
+          if (event.touches.length < 2) {
+            pinchStartDistance = null;
+          }
+        };
+
+        itemGridElement.addEventListener("touchstart", onTouchStart, { passive: false });
+        itemGridElement.addEventListener("touchmove", onTouchMove, { passive: false });
+        itemGridElement.addEventListener("touchend", onTouchEnd, { passive: true });
+        itemGridElement.addEventListener("touchcancel", onTouchEnd, { passive: true });
+      }
+
+
+      function updateScrollUI() {
+        const scrollY = Math.max(window.scrollY || window.pageYOffset || 0, 0);
+
         if (window.scrollY > 400) {
-          // Adjust this value based on when you want it to appear
           document.querySelector(".back-to-top-button").style.opacity = "1";
           document.querySelector(".back-to-top-button").style.display = "block";
           document.querySelector(".footer").style.opacity = "1";
@@ -389,24 +443,40 @@
           document.querySelector(".back-to-top-button").style.display = "none";
           document.querySelector(".footer").style.opacity = "0";
         }
-      });
-      
-      // JavaScript to toggle the class on scroll
-      let lastScrollTop = 0;
-      const nav = document.querySelector('.navigation');
 
-      window.addEventListener('scroll', () => {
-        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-        if (scrollTop > lastScrollTop && !navActive) {
-          // User is scrolling down
-          hideNav();
-        }
-        else {
-          // User is scrolling up
+        if (isMobileViewport()) {
+          const controlsHeight = nav.offsetHeight || 0;
+          const atTop = scrollY <= 4;
+          const controlsVisible = atTop || scrollY <= controlsHeight + 24;
+          body.classList.toggle("mobile-controls-visible", controlsVisible);
+          document.documentElement.style.setProperty("--mobile-controls-offset", `${controlsHeight}px`);
+          const shouldShowSidebar = !controlsVisible && scrollY > controlsHeight + 24;
+          setMobileSidebarVisible(shouldShowSidebar);
+        } else {
+          body.classList.remove("mobile-sidebar-visible");
+          body.classList.remove("mobile-controls-visible");
+          sidebarActive = false;
+          navActive = true;
           showNav();
         }
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop; // Ensure scrollTop doesn't go negative
-      });
+      }
+
+      function onScroll() {
+        if (scrollRafId !== null) {
+          return;
+        }
+
+        scrollRafId = requestAnimationFrame(() => {
+          updateScrollUI();
+          scrollRafId = null;
+        });
+      }
+
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", () => {
+        adjustPinnedStyles();
+        updateScrollUI();
+      }, { passive: true });
 
       document
         .querySelector(".back-to-top-button")
@@ -462,6 +532,7 @@
     const img = document.createElement("img");
     img.src = `pages/${page}/icons/${item.image}`;
     img.alt = item.name;
+    img.draggable = false;
 
     const name = document.createElement("p");
     name.textContent = item.name;
@@ -608,6 +679,11 @@
 function initializeDragAndDrop() {
     const itemGrid = document.getElementById('itemGrid');
     const outfitSlotsContainer = document.getElementById('outfitSlots');
+    const slotElements = outfitSlotsContainer.querySelectorAll('.slot');
+
+    const clearDropTargets = () => {
+        slotElements.forEach(slot => slot.classList.remove('drop-target'));
+    };
 
     // Make each item card draggable
     itemGrid.querySelectorAll('.item-card').forEach(card => {
@@ -617,16 +693,33 @@ function initializeDragAndDrop() {
         card.addEventListener('dragstart', (event) => {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
+            event.dataTransfer.effectAllowed = 'move';
+            card.classList.add('dragging');
+            document.body.classList.add('is-dragging-item');
+        });
+
+        card.addEventListener('dragend', () => {
+            card.classList.remove('dragging');
+            document.body.classList.remove('is-dragging-item');
+            clearDropTargets();
         });
     });
 
-    // Enable outfitSlots as the drop target
-    outfitSlotsContainer.addEventListener('dragover', (event) => {
-        event.preventDefault();  // Allow item to be dropped
+    slotElements.forEach(slot => {
+        slot.addEventListener('dragover', (event) => {
+            event.preventDefault();  // Allow item to be dropped
+            slot.classList.add('drop-target');
+        });
+
+        slot.addEventListener('dragleave', () => {
+            slot.classList.remove('drop-target');
+        });
     });
 
     outfitSlotsContainer.addEventListener('drop', (event) => {
         event.preventDefault();
+        clearDropTargets();
+        document.body.classList.remove('is-dragging-item');
         const itemName = event.dataTransfer.getData('text/plain');  // Get item name
 
         // Verify that itemName data was successfully retrieved
@@ -635,33 +728,26 @@ function initializeDragAndDrop() {
             return;
         }
         
-        // Find item type from the JSON data
-        fetch(`pages/${page}/typed_items_for_web.json`)
-            .then(response => response.json())
-            .then(jsonData => {
-                const item = jsonData.find(i => i.name === itemName);
+        const item = items.find(i => i.name === itemName);
 
-                if (!item) {
-                    console.error("Item not found in JSON data:", itemName);
-                    return;
-                }
+        if (!item) {
+            console.error("Item not found in loaded item data:", itemName);
+            return;
+        }
 
-                let slotType = `${item.type}Slot`; // Default slot type based on item type
+        let slotType = `${item.type}Slot`; // Default slot type based on item type
 
-				// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
-				if (item.type === 'weapons' || item.type === 'shields') {
-					const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
-					const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
+		// If the item is of type 'weapons' or 'shields', allow it to go in either slot if available
+		if (item.type === 'weapons' || item.type === 'shields') {
+			const outfitSlots = JSON.parse(localStorage.getItem(gamePrefix + 'outfitSlots')) || {};
+			const alternateSlot = slotType === 'weaponsSlot' ? 'shieldsSlot' : 'weaponsSlot';
 
-					// Assign to the specified slot if empty, otherwise use the alternate slot
-					slotType = outfitSlots[slotType] ? alternateSlot : slotType;
-				}
+			// Assign to the specified slot if empty, otherwise use the alternate slot
+			slotType = outfitSlots[slotType] ? alternateSlot : slotType;
+		}
 
-                
-                // Update the specified slot with the dropped item
-                addItemToSlot(slotType, item);
-            })
-            .catch(error => console.error("Error loading JSON data:", error));
+        // Update the specified slot with the dropped item
+        addItemToSlot(slotType, item);
     });
 }
 
@@ -687,6 +773,9 @@ window.onload = function() {
         initializeItemGrid();
         initializeDragAndDrop();  // Enable drag-and-drop on items
         adjustPinnedStyles();
+        updateScrollUI();
+        initGridZoomControl();
+        setupPinchZoom();
     });
 
 };
@@ -707,21 +796,29 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
     });
 });
-
-
-window.onresize = adjustPinnedStyles;
-
-
   </script>
-  
-  <script>
-    window.addEventListener("load", () => {
+    <script>
+    (function setupPreloader() {
         const preloader = document.getElementById("preloader");
-        preloader.style.opacity = "0"; // Fade out effect
-        setTimeout(() => {
-            preloader.style.display = "none"; // Completely hide after fading
-        }, 3000); // Duration of fade effect in milliseconds
-    });
+        if (!preloader) {
+            return;
+        }
+
+        let hidden = false;
+        const hidePreloader = () => {
+            if (hidden) return;
+            hidden = true;
+            preloader.classList.add("hidden");
+            setTimeout(() => {
+                preloader.style.display = "none";
+            }, 650);
+        };
+
+        window.addEventListener("initial-grid-images-loaded", hidePreloader, { once: true });
+        window.addEventListener("load", () => {
+            setTimeout(hidePreloader, 2600);
+        }, { once: true });
+    })();
 </script>
   
   </body>

--- a/eldenring.html
+++ b/eldenring.html
@@ -177,14 +177,17 @@
       </ul>
     </div>
 
+    <div class="grid-zoom-panel" aria-label="Tile zoom control">
+      <div class="grid-zoom-control">
+        <span class="zoom-symbol" aria-hidden="true">−</span>
+        <input type="range" id="gridZoomSlider" min="0" max="3" step="1" value="1" />
+        <span class="zoom-symbol" aria-hidden="true">+</span>
+      </div>
+      <p id="gridZoomValue" class="grid-zoom-value">103.3%</p>
+    </div>
+
     <div class="hover-trigger">
       <div class="pinned">
-          <div class="grid-zoom-control" aria-label="Tile zoom control">
-            <span class="zoom-symbol" aria-hidden="true">−</span>
-            <input type="range" id="gridZoomSlider" min="33.3" max="200" step="0.1" value="100" />
-            <span class="zoom-symbol" aria-hidden="true">+</span>
-          </div>
-          <p id="gridZoomValue" class="grid-zoom-value">100%</p>
         <!-- <div class="tooltip">
           <span class="tooltip-text">
             To commit an item to the outfit simulator, right click an item card and select 'send to outfit simulator'.
@@ -346,10 +349,30 @@
         window.location.href = `simulator_${page}.html`;
       });
 
-      let currentGridScale = 100;
+      const GRID_ZOOM_LEVELS = [80, 103.3, 126.7, 150];
+      let currentGridScale = GRID_ZOOM_LEVELS[1];
+
+      function findClosestGridZoomIndex(value) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+          return 1;
+        }
+
+        let closestIndex = 0;
+        let closestDistance = Infinity;
+        GRID_ZOOM_LEVELS.forEach((zoomLevel, index) => {
+          const distance = Math.abs(zoomLevel - numericValue);
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = index;
+          }
+        });
+        return closestIndex;
+      }
 
       function applyGridScale(value, persist = true) {
-        const clampedValue = Math.min(200, Math.max(33.3, Number(value) || 100));
+        const numericValue = Number(value);
+        const clampedValue = Math.min(150, Math.max(80, Number.isFinite(numericValue) ? numericValue : GRID_ZOOM_LEVELS[1]));
         currentGridScale = clampedValue;
         const scaleFactor = clampedValue / 100;
         document.documentElement.style.setProperty("--item-card-scale", scaleFactor.toString());
@@ -357,14 +380,14 @@
         const gridZoomSlider = document.getElementById("gridZoomSlider");
         const gridZoomValue = document.getElementById("gridZoomValue");
         if (gridZoomSlider) {
-          gridZoomSlider.value = clampedValue.toFixed(1);
+          gridZoomSlider.value = String(findClosestGridZoomIndex(clampedValue));
         }
         if (gridZoomValue) {
-          gridZoomValue.textContent = `${Math.round(clampedValue)}%`;
+          gridZoomValue.textContent = `${clampedValue.toFixed(1)}%`;
         }
 
         if (persist) {
-          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toString());
+          localStorage.setItem(`${gamePrefix}tileSizeScale`, clampedValue.toFixed(1));
         }
       }
 
@@ -374,11 +397,14 @@
           return;
         }
 
-        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`)) || 100;
-        applyGridScale(savedValue, false);
+        const savedValue = Number(localStorage.getItem(`${gamePrefix}tileSizeScale`));
+        const initialValue = Number.isFinite(savedValue) ? Math.min(150, Math.max(80, savedValue)) : GRID_ZOOM_LEVELS[1];
+        applyGridScale(initialValue, false);
 
         gridZoomSlider.addEventListener("input", (event) => {
-          applyGridScale(event.target.value);
+          const zoomIndex = Number(event.target.value);
+          const zoomValue = GRID_ZOOM_LEVELS[zoomIndex] ?? GRID_ZOOM_LEVELS[1];
+          applyGridScale(zoomValue);
         });
       }
 
@@ -694,11 +720,33 @@ function initializeDragAndDrop() {
             const itemInfo = card.querySelector('.item-info .title-container a').textContent;
             event.dataTransfer.setData('text/plain', itemInfo);  // Set item name as drag data
             event.dataTransfer.effectAllowed = 'move';
+
+            let dragPreview = null;
+            if (!isMobileViewport()) {
+                dragPreview = card.cloneNode(true);
+                dragPreview.classList.add('drag-preview');
+                dragPreview.style.position = 'fixed';
+                dragPreview.style.top = '-9999px';
+                dragPreview.style.left = '-9999px';
+                dragPreview.style.width = `${card.offsetWidth}px`;
+                dragPreview.style.pointerEvents = 'none';
+                dragPreview.style.transform = 'scale(0.6)';
+                dragPreview.style.transformOrigin = 'top left';
+                dragPreview.style.zIndex = '9999';
+                document.body.appendChild(dragPreview);
+                event.dataTransfer.setDragImage(dragPreview, 20, 20);
+            }
+
+            card._dragPreview = dragPreview;
             card.classList.add('dragging');
             document.body.classList.add('is-dragging-item');
         });
 
         card.addEventListener('dragend', () => {
+            if (card._dragPreview) {
+                card._dragPreview.remove();
+                card._dragPreview = null;
+            }
             card.classList.remove('dragging');
             document.body.classList.remove('is-dragging-item');
             clearDropTargets();

--- a/feedback.html
+++ b/feedback.html
@@ -3,8 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.5">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
 		<link rel="icon" type="image/x-icon" href="icon.ico">
 		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
@@ -13,7 +15,7 @@
 		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
 		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
 		<link rel="icon" href="favicon.ico">
-    <title>Feedback - Fashion Souls v1.0.8</title>
+    <title>Feedback - Fashion Souls v1.0.9</title>
     
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,72 +4,132 @@
 	<link rel="manifest" href="resources/site.webmanifest">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="description" content="Discover stylish, color-matching outfits for your favorite SoulsBorne games with souls.fashion. Find coordinated looks for Elden Ring, Dark Souls 1-3, Bloodborne, and more – your go-to tool for in-game fashion inspiration!">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-		<link rel="icon" type="image/x-icon" href="icon.ico">
-		<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
-		<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
-		<link rel="icon" type="image/png" sizes="48x48" href="favicons/icon_48x48.png">
-		<link rel="icon" type="image/png" sizes="96x96" href="favicons/icon_96x96.png">
-		<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png"> 
-		<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
-		<link rel="icon" href="favicon.ico">
-    <title>Fashion Souls v1.0.8</title>
+	<meta name="description" content="Curate by colour for the perfect SoulsBourne drip with souls.fashion. Discover outfits for Elden Ring, Dark Souls 1-3, Bloodborne and Demons' Souls with the premier web-hosted fashion tool!">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="icon" type="image/x-icon" href="icon.ico">
+	<link rel="icon" type="image/png" sizes="16x16" href="favicons/icon_16x16.png">
+	<link rel="icon" type="image/png" sizes="32x32" href="favicons/icon_32x32.png">
+	<link rel="icon" type="image/png" sizes="48x48" href="favicons/icon_48x48.png">
+	<link rel="icon" type="image/png" sizes="96x96" href="favicons/icon_96x96.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="167x167" href="favicons/icon_167x167.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="favicons/icon_180x180.png">
+	<link rel="icon" href="favicon.ico">
+    <title>Fashion Souls v1.0.9</title>
     <style>
-        h2 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 70px;margin-top:-10px;}
-        h3 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 20px;margin-top:-70px;}
+        *, *::before, *::after { box-sizing: border-box; }
+
+        :root {
+            --tile-width: 250px;
+        }
+
+        h2 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 70px;margin: 0;}
+        h3 {text-align: center;font-family: "Spectral",'fallback', Helvetica, Arial, sans-serif;font-size: 20px;margin: 0;}
+
         body {
             font-family: "Spectral", 'fallback', Helvetica, Arial, sans-serif;
             margin: 0;
-            padding: 20px;
+            padding: 0;
             background-color: #121212;
             color: #ffffff;
-            transition: background-color 0.5s ease, color 0.5s ease, opacity 0.5s ease; /* Combined transitions */
+            transition: background-color 0.5s ease, color 0.5s ease, opacity 0.5s ease;
             opacity: 1;
-            visibility: visible; /* Initial visibility */
-            padding-bottom: 40px; /* Add padding at the bottom to prevent content overlap */
+            visibility: visible;
+            padding-bottom: 55px;
         }
-        .fade-out {
-            opacity: 0; /* Fade-out effect */
-            visibility: hidden; /* Hide the body */
+
+        .fade-out {opacity: 0;visibility: hidden;}
+
+        .hero {
+            position: sticky;
+            top: 0;
+            z-index: 20;
+            background: rgba(18, 18, 18, 0.95);
+            backdrop-filter: blur(4px);
+            padding: 14px 16px 12px;
+            border-bottom: 1px solid #333;
         }
+
+        .hero-text {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+
+
         .item-grid {
             display: flex;
             flex-wrap: wrap;
             gap: 20px;
-            justify-content: center; /* Center the grid */
+            justify-content: center;
+            padding: 20px;
         }
+
         .item-card {
             background-color: #333;
             border: 1px solid #555;
-            padding: 20px; /* Increased padding for a larger tile */
-            width: 250px; /* Adjust width for larger tiles */
+            padding: 14px;
+            flex: 0 1 var(--tile-width);
+            width: var(--tile-width);
             text-align: center;
             color: #fff;
+            transition: width 0.2s ease, transform 0.2s ease;
         }
+
+        .item-card:hover {transform: translateY(-2px);}
+
+        .item-media {
+            width: 100%;
+            aspect-ratio: 10 / 16;
+            overflow: hidden;
+            background: #202020;
+        }
+
         .item-card img {
-            max-width: 100%;
-            height: auto;
+            display: block;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
         }
+
         .copyright {
-            position: fixed; /* Fix to the bottom */
-            bottom: 0; /* Position at the bottom of the viewport */
-            left: 0; /* Align to the left */
-            right: 0; /* Align to the right */
-            text-align: center; /* Center the copyright text */
-            margin: 0; /* Remove margin */
-            padding: 10px 0; /* Padding for spacing */
-            font-size: 14px; /* Font size for the copyright */
-            color: #333333; /* Color for the copyright text */
-            background-color: rgba(18, 18, 18, 0.8); /* Background color with some transparency */
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            text-align: center;
+            margin: 0;
+            padding: 10px 0;
+            font-size: 14px;
+            color: #333333;
+            background-color: rgba(18, 18, 18, 0.8);
+        }
+
+        @media (max-width: 900px) {
+            h2 {font-size: 50px;}
+            h3 {font-size: 14px;}
+            .item-grid {padding: 14px; gap: 14px;}
+            .item-card {
+                flex: 0 1 calc((100% - 14px) / 2);
+                width: calc((100% - 14px) / 2);
+                max-width: calc((100% - 14px) / 2);
+                min-width: 0;
+                padding: 10px;
+            }
         }
     </style>
 </head>
 <body>
-<div class="FashionSouls">
-    <h2>Fashion Souls</h2>
-    <h3 style="color: #bfbfbf">SoulsBorne fashion tool by Psyopgirl</h3>
+<div class="hero">
+    <div class="hero-text">
+        <h2>Fashion Souls</h2>
+        <h3 style="color: #bfbfbf">SoulsBorne Fashion Tool by Psyopgirl</h3>
+
+    </div>
 </div>
+
 <div class="item-grid" id="itemGrid">
     <!-- Images will be dynamically loaded here -->
 </div>
@@ -80,49 +140,26 @@
 </div>
 
 <script>
-    // Function to load images dynamically with placeholders
+
     function loadImages() {
         const itemGrid = document.getElementById('itemGrid');
         const items = [
-            {
-                img: 'https://i.ibb.co/Zz6L6c6/elden-ring-grid.webp',
-                placeholder: 'resources/grid-images/elden-ring-grid_placeholder.webp',
-                link: 'eldenring'
-            },
-            {
-                img: 'https://i.ibb.co/0Zk0dbB/bloodborne-grid.webp',
-                placeholder: 'resources/grid-images/bloodborne-grid_placeholder.webp',
-                link: 'bloodborne'
-            },
-            {
-                img: 'https://i.ibb.co/1rLcBQG/dark-souls-grid.webp',
-                placeholder: 'resources/grid-images/dark-souls-grid_placeholder.webp',
-                link: 'ds1'
-            },
-            {
-                img: 'https://i.ibb.co/gFfpdmD/dark-souls-2-grid.webp',
-                placeholder: 'resources/grid-images/dark-souls-2-grid_placeholder.webp',
-                link: 'ds2'
-            },
-            {
-                img: 'https://i.ibb.co/NT663zC/dark-souls-3-grid.webp',
-                placeholder: 'resources/grid-images/dark-souls-3-grid_placeholder.webp',
-                link: 'ds3'
-            },
-            {
-                img: 'https://i.ibb.co/zRmBHft/demons-souls-grid.webp',
-                placeholder: 'resources/grid-images/demons-souls-grid_placeholder.webp',
-                link: 'demonssouls'
-            }
+            {img: 'https://i.ibb.co/Zz6L6c6/elden-ring-grid.webp', placeholder: 'resources/grid-images/elden-ring-grid_placeholder.webp', link: 'eldenring'},
+            {img: 'https://i.ibb.co/0Zk0dbB/bloodborne-grid.webp', placeholder: 'resources/grid-images/bloodborne-grid_placeholder.webp', link: 'bloodborne'},
+            {img: 'https://i.ibb.co/1rLcBQG/dark-souls-grid.webp', placeholder: 'resources/grid-images/dark-souls-grid_placeholder.webp', link: 'ds1'},
+            {img: 'https://i.ibb.co/gFfpdmD/dark-souls-2-grid.webp', placeholder: 'resources/grid-images/dark-souls-2-grid_placeholder.webp', link: 'ds2'},
+            {img: 'https://i.ibb.co/NT663zC/dark-souls-3-grid.webp', placeholder: 'resources/grid-images/dark-souls-3-grid_placeholder.webp', link: 'ds3'},
+            {img: 'https://i.ibb.co/zRmBHft/demons-souls-grid.webp', placeholder: 'resources/grid-images/demons-souls-grid_placeholder.webp', link: 'demonssouls'}
         ];
 
-        itemGrid.innerHTML = ''; // Clear existing content
+        itemGrid.innerHTML = '';
 
         items.forEach(item => {
             const itemCard = document.createElement('div');
             itemCard.className = 'item-card';
-            const linkElement = document.createElement('a');
 
+            const linkElement = document.createElement('a');
+            linkElement.href = item.link;
             linkElement.addEventListener('click', function(e) {
                 e.preventDefault();
                 document.body.classList.add('fade-out');
@@ -131,39 +168,40 @@
                 }, 500);
             });
 
+            const mediaElement = document.createElement('div');
+            mediaElement.className = 'item-media';
+
             const imgElement = document.createElement('img');
-            imgElement.src = item.placeholder; // Load the placeholder initially
+            imgElement.loading = 'lazy';
+            imgElement.decoding = 'async';
+            imgElement.src = item.placeholder;
             imgElement.alt = item.link;
 
-            // Load the animated image after placeholder is loaded
             const animatedImg = new Image();
             animatedImg.src = item.img;
             animatedImg.onload = function() {
-                imgElement.src = animatedImg.src; // Replace with animated image
+                imgElement.src = animatedImg.src;
             };
 
-            linkElement.appendChild(imgElement);
+            mediaElement.appendChild(imgElement);
+            linkElement.appendChild(mediaElement);
             itemCard.appendChild(linkElement);
             itemGrid.appendChild(itemCard);
         });
     }
 
-    // Call the function to load images on page load
     window.onload = function() {
         loadImages();
-        document.body.classList.remove('fade-out'); // Ensure fade-out is removed on load
+        document.body.classList.remove('fade-out');
     };
 
-    // Listen for visibility change to manage the fade-in effect
     document.addEventListener('visibilitychange', function() {
         if (document.visibilityState === 'visible') {
-            document.body.classList.remove('fade-out'); // Remove fade-out when coming back
+            document.body.classList.remove('fade-out');
         } else {
-            document.body.classList.add('fade-out'); // Add fade-out when leaving
+            document.body.classList.add('fade-out');
         }
     });
 </script>
-
-
 </body>
 </html>

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -3,6 +3,16 @@
   user-select: none;
 }
 
+img {
+  -webkit-user-drag: none;
+  -webkit-touch-callout: none;
+}
+
+:root {
+  --item-card-scale: 1;
+  --mobile-controls-offset: 11.25rem;
+}
+
 h2 {
   letter-spacing: -0.25rem; /* -4px */
   line-height: 0.5;
@@ -374,6 +384,7 @@ body.light-mode .color-picker:hover {
   height: 1.875rem; /* 30px */
   width: 4.375rem; /* 70px */
   font-size: 0.75rem; /* 12px */
+  font-family: "Spectral", "fallback", Helvetica, Arial, sans-serif;
 }
 
 .filters-group #clearFilter {
@@ -408,6 +419,85 @@ body.light-mode .filters-group button.active {
   color: white;
   border-color: #007bff;
 }
+
+.grid-zoom-control {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  margin-bottom: 0.35rem;
+  padding: 0.35rem 0.3rem;
+  border: 0.0625rem solid #3f3f3f;
+  border-radius: 0.5rem;
+  background-color: rgba(20, 20, 20, 0.92);
+}
+
+.grid-zoom-control .zoom-symbol {
+  color: #d6d6d6;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.grid-zoom-control input[type="range"] {
+  width: 3.2rem;
+}
+
+.grid-zoom-value {
+  margin: 0 0 0.45rem 0;
+  text-align: center;
+  color: #a8a8a8;
+  font-size: 0.68rem;
+}
+
+.slider-container input[type="range"],
+.grid-zoom-control input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 0.275rem;
+  border-radius: 999px;
+  background: #2d2d2d;
+  outline: none;
+  border: 0.0625rem solid #4a4a4a;
+}
+
+.slider-container input[type="range"]::-webkit-slider-thumb,
+.grid-zoom-control input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  background: #d9d9d9;
+  border: 0.125rem solid #2f2f2f;
+  cursor: pointer;
+}
+
+.slider-container input[type="range"]::-moz-range-thumb,
+.grid-zoom-control input[type="range"]::-moz-range-thumb {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 50%;
+  background: #d9d9d9;
+  border: 0.125rem solid #2f2f2f;
+  cursor: pointer;
+}
+
+body.light-mode .slider-container input[type="range"],
+body.light-mode .grid-zoom-control input[type="range"] {
+  background: #d8d8d8;
+  border-color: #b8b8b8;
+}
+
+body.light-mode .grid-zoom-control {
+  background-color: rgba(245, 245, 245, 0.95);
+  border-color: #bbbbbb;
+}
+
+body.light-mode .grid-zoom-control .zoom-symbol,
+body.light-mode .grid-zoom-value {
+  color: #222;
+}
+
 
 .dropdown .dropbtn {
   all: unset;
@@ -459,6 +549,7 @@ body.light-mode .dropdown .dropbtn {
   vertical-align: middle;
   text-align: center;
   margin-left: 6.5rem;
+  transition: margin-left 0.3s ease;
 }
 
 .item-card {
@@ -467,12 +558,20 @@ body.light-mode .dropdown .dropbtn {
   background-color: none;
   border: 0.0625rem solid #555; /* 1px */
   padding: 0.625rem; /* 10px */
-  width: 12.5rem; /* 200px */
-  height: 18.75rem; /* 300px */
+  width: calc(12.5rem * var(--item-card-scale)); /* 200px */
+  height: calc(18.75rem * var(--item-card-scale)); /* 300px */
   text-align: center;
   color: #fff;
-  transition: transform 0.3s ease, border-color 0.3s ease;
+  transition: transform 0.3s ease, border-color 0.3s ease, width 0.2s ease,
+    height 0.2s ease;
   border-radius: 0.625rem; /* 10px */
+  touch-action: pan-y;
+}
+
+.item-card.dragging {
+  opacity: 0.75;
+  transform: scale(1.02);
+  border-color: #8c8c8c;
 }
 
 .item-card-simple {
@@ -515,8 +614,17 @@ body.light-mode .item-card-simple {
 }
 
 .item-card img {
+  pointer-events: none;
+  user-select: none;
+  width: 100%;
+  aspect-ratio: 1 / 1;
   max-width: 100%;
   height: auto;
+  object-fit: contain;
+}
+
+.image-container {
+  aspect-ratio: 1 / 1;
 }
 
 .image-container,
@@ -640,6 +748,10 @@ body.light-mode .color-bar div:hover {
   transform: translateY(-50%);
 }
 
+body.is-dragging-item .pinned {
+  box-shadow: 0 0 0.5rem rgba(255, 235, 59, 0.6);
+}
+
 body.light-mode .pinned {
   border: 0.0625rem solid #999; /* 1px */
   background-color: white;
@@ -683,7 +795,6 @@ body.light-mode .pinned {
 }
 
 .slot {
-  background-color: transparent;
   width: 100%;
   height: 5rem;
   position: relative;
@@ -691,33 +802,59 @@ body.light-mode .pinned {
 
 .placeholder-tile {
   margin-top: 15px;
+  border-radius: 0.375rem;
+  background-color: #0f0f0f;
   display: flex;
   align-items: center;
   text-align: center;
   justify-content: center;
-  background-color: transparent;
   width: 100%;
   height: 5rem;
 }
 
 .placeholder-tile p {
   color: #777;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.2rem;
 }
 
 .slot p {
   text-align: center;
   position: absolute;
-  vertical-align: middle;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   color: #777;
+  font-size: 0.55rem;
+  line-height: 1.15;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 0 0.15rem;
+  overflow-wrap: anywhere;
 }
 
 .slot img {
+  pointer-events: none;
+  user-select: none;
   width: 100%;
   height: auto;
   background-color: #000;
   z-index: 1001;
   border: 0.0625rem solid #555; /* 1px */
   border-radius: 0.625rem; /* 10px */
+}
+
+.slot.drop-target img,
+.slot.drop-target .placeholder-tile {
+  outline: 0.125rem dashed #ffeb3b;
+  outline-offset: 0.125rem;
 }
 
 .back-to-top-button {
@@ -1094,8 +1231,25 @@ body.light-mode .custom-context-menu ul li:hover {
 
   .FashionSouls {
     display: block;
-    margin-top: 9.375rem; /* 150px */
-    margin-bottom: 6.25rem; /* 100px */
+    position: sticky;
+    top: 4.1rem;
+    z-index: 1001;
+    margin-top: 0.15rem;
+    margin-bottom: 0.5rem;
+    padding: 0.25rem 0.15rem;
+    background-color: rgba(18, 18, 18, 0.94);
+    border-bottom: 0.0625rem solid #232323;
+  }
+
+  .FashionSouls h2 {
+    font-size: 1.85rem;
+    line-height: 1;
+  }
+
+  .FashionSouls h3 {
+    margin-top: 0.2rem;
+    font-size: 0.7rem;
+    line-height: 1.1;
   }
 
   .FashionSouls-simple {
@@ -1109,6 +1263,20 @@ body.light-mode .custom-context-menu ul li:hover {
   .navigation {
     padding-right: 5%;
     padding-left: 5%;
+    position: sticky;
+    max-height: 100dvh;
+    overflow-y: auto;
+  }
+
+  .topnav {
+    position: sticky;
+    top: 0;
+    z-index: 1002;
+    background-color: #121212;
+  }
+
+  body.light-mode .topnav {
+    background-color: #fff;
   }
 
   .topnav-simple {
@@ -1129,7 +1297,7 @@ body.light-mode .custom-context-menu ul li:hover {
     width: 12.5rem; /* 200px */
     background-color: #121212;
     transition: right 0.3s ease-in-out;
-    z-index: 1000; /* Above other content */
+    z-index: 5000; /* Above other content */
     color: white;
     padding: 1.25rem; /* 20px */
     padding-top: 6.25rem; /* 100px */
@@ -1215,8 +1383,12 @@ body.light-mode .custom-context-menu ul li:hover {
     margin-left: 0;
   }
 
+  body.mobile-sidebar-visible .item-grid {
+    margin-left: 4.8rem;
+  }
+
   .item-card {
-    width: 40%;
+    width: calc(40% * var(--item-card-scale));
     height: auto;
   }
 
@@ -1238,12 +1410,25 @@ body.light-mode .custom-context-menu ul li:hover {
   }
 
   .pinned {
-    top: 50%;
+    top: calc(var(--mobile-controls-offset) + 0.5rem);
     left: 0;
-    transform: translateY(-50%);
+    transform: translate(-120%, 0);
     opacity: 0;
-    display: none;
-    width: 3.75rem; /* 60px */
+    display: block;
+    width: 5.25rem;
+    max-height: calc(100dvh - var(--mobile-controls-offset) - 0.75rem);
+    overflow-y: auto;
+    transition: transform 0.25s ease, opacity 0.25s ease;
+  }
+
+  body.mobile-sidebar-visible .pinned {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+
+  body.mobile-controls-visible .pinned {
+    transform: translate(-120%, 0);
+    opacity: 0;
   }
 
   .pinned-buttons button {
@@ -1253,21 +1438,27 @@ body.light-mode .custom-context-menu ul li:hover {
     font-size: 0.75rem; /* 12px */
   }
 
+  .grid-zoom-control,
+  .grid-zoom-value {
+    display: none;
+  }
+
   .placeholder-tile {
-    font-size: 0.375rem; /* 6px */
+    font-size: 0.45rem;
   }
 
   .placeholder-tile p {
-    font-size: 0.5rem;
+    font-size: 0.55rem;
+    line-height: 1.15;
   }
 
   .slot {
-    width: 3.125rem; /* 50px */
-    height: 3.125rem; /* 50px */
+    width: 4.2rem;
+    height: 4.2rem;
   }
 
   .back-to-top-button {
-    font-size: 0.625rem; /* 10px */
+    font-size: 0.875rem; /* 14px */
     margin: 0.625rem; /* 10px */
   }
 
@@ -1296,7 +1487,105 @@ body.light-mode .custom-context-menu ul li:hover {
   }
 
   .hover-trigger {
-    width: 2rem;
+    width: 4.5rem;
+    pointer-events: none;
+  }
+
+
+  .hover-trigger .pinned {
+    pointer-events: auto;
+  }
+}
+
+@media (min-width: 0px) and (max-width: 1199px) {
+  #backToMain {
+    width: auto;
+    max-width: 64vw;
+    font-size: 0.72rem;
+    padding: 0.25rem 0.5rem;
+  }
+
+  .outfit-sim {
+    align-items: stretch;
+    padding: 3.1rem 5.8rem 0.5rem 0.5rem;
+  }
+
+  .outfit-sim-header h1 {
+    font-size: 0.95rem;
+    line-height: 1.25;
+    margin: 0 0 0.35rem 0;
+  }
+
+  #downloadImageLink {
+    font-size: 0.75rem;
+    margin: 0.15rem 0 0.5rem 0;
+  }
+
+  #presetContainer {
+    top: 2.8rem;
+    right: 0.25rem;
+    transform: none;
+    width: 5.2rem;
+    padding: 0.35rem;
+    gap: 0.35rem;
+    max-height: calc(100dvh - 3.3rem);
+    overflow-y: auto;
+    border-radius: 0.4rem;
+  }
+
+  .preset {
+    width: 100%;
+    padding: 0.35rem;
+    border-radius: 0.35rem;
+  }
+
+  .preset h3 {
+    font-size: 0.58rem;
+    margin: 0;
+    line-height: 1.2;
+    min-height: 1.2rem;
+  }
+
+  .preset-actions {
+    margin-top: 0.2rem;
+    line-height: 1.1;
+  }
+
+  .preset-actions span {
+    font-size: 0.5rem;
+  }
+
+  #outfitSlotsSimulator.simulator-grid {
+    width: 100%;
+    gap: 0.4rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  #headCard,
+  #chestCard,
+  #handsCard,
+  #legsCard,
+  #weaponsCard,
+  #shieldsCard {
+    width: 100%;
+    min-width: 0;
+    height: auto;
+    min-height: 8.4rem;
+    padding: 0.35rem;
+    border-radius: 0.45rem;
+    font-size: 0.58rem;
+  }
+
+  #outfitSlotsSimulator .item-card-simple img,
+  #headCard img,
+  #chestCard img,
+  #handsCard img,
+  #legsCard img,
+  #weaponsCard img,
+  #shieldsCard img {
+    max-height: 4.5rem;
+    width: 100%;
+    object-fit: contain;
   }
 }
 
@@ -1423,11 +1712,21 @@ body.light-mode .custom-context-menu ul li:hover {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 3000;
     text-align: center;
+    padding: 1rem;
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.3s ease;
+}
+
+.notice-content {
+    max-width: 40rem;
+    line-height: 1.5;
+}
+
+.notice-content a {
+    color: #ffeb3b;
 }
 
 .full-screen-notice.show {
@@ -1443,6 +1742,8 @@ body.light-mode .custom-context-menu ul li:hover {
 
 .preloader {
     position: fixed;
+    opacity: 1;
+    transition: opacity 0.6s ease;
     top: 0;
     left: 0;
     width: 100vw;
@@ -1451,7 +1752,12 @@ body.light-mode .custom-context-menu ul li:hover {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 5000;
+}
+
+.preloader.hidden {
+    opacity: 0;
+    pointer-events: none;
 }
 
 .preloader-logo {

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -420,6 +420,16 @@ body.light-mode .filters-group button.active {
   border-color: #007bff;
 }
 
+.grid-zoom-panel {
+  position: fixed;
+  top: 50%;
+  left: 0;
+  transform: translateY(calc(-50% - 15.4rem));
+  width: 6rem;
+  margin: 0.625rem;
+  z-index: 25;
+}
+
 .grid-zoom-control {
   display: flex;
   align-items: center;
@@ -491,6 +501,10 @@ body.light-mode .grid-zoom-control input[type="range"] {
 body.light-mode .grid-zoom-control {
   background-color: rgba(245, 245, 245, 0.95);
   border-color: #bbbbbb;
+}
+
+body.light-mode .grid-zoom-panel {
+  color: #222;
 }
 
 body.light-mode .grid-zoom-control .zoom-symbol,
@@ -1438,6 +1452,7 @@ body.light-mode .custom-context-menu ul li:hover {
     font-size: 0.75rem; /* 12px */
   }
 
+  .grid-zoom-panel,
   .grid-zoom-control,
   .grid-zoom-value {
     display: none;

--- a/search_items.js
+++ b/search_items.js
@@ -1,6 +1,7 @@
 let items = []; // To store items loaded from JSON
 let colorDistanceThreshold = 100; // Default threshold value
 let activeFilters = new Set(); // To track active filters
+let hasNotifiedInitialGridLoad = false;
 
 // Store page name as var
 var url = window.location.href;
@@ -175,6 +176,35 @@ function displayItems(filteredItems) {
     const itemCard = createItemCard(item);
     itemGrid.appendChild(itemCard);
   });
+
+  if (!hasNotifiedInitialGridLoad) {
+    const imageNodes = Array.from(itemGrid.querySelectorAll(".item-card img")).slice(0, 24);
+    if (imageNodes.length === 0) {
+      window.dispatchEvent(new CustomEvent("initial-grid-images-loaded"));
+      hasNotifiedInitialGridLoad = true;
+      return;
+    }
+
+    const imageLoadPromises = imageNodes.map(img => {
+      if (img.complete && img.naturalWidth > 0) {
+        return Promise.resolve();
+      }
+      return new Promise(resolve => {
+        img.addEventListener("load", resolve, { once: true });
+        img.addEventListener("error", resolve, { once: true });
+      });
+    });
+
+    Promise.race([
+      Promise.all(imageLoadPromises),
+      new Promise(resolve => setTimeout(resolve, 2500)),
+    ]).then(() => {
+      if (!hasNotifiedInitialGridLoad) {
+        hasNotifiedInitialGridLoad = true;
+        window.dispatchEvent(new CustomEvent("initial-grid-images-loaded"));
+      }
+    });
+  }
 }
 
 // Function to create item cards with click event for search
@@ -188,6 +218,9 @@ function createItemCard(item) {
   const imageContainer = document.createElement("div");
   imageContainer.classList.add("image-container");
   const img = document.createElement("img");
+  img.loading = "lazy";
+  img.decoding = "async";
+  img.draggable = false;
   img.src = `pages/${page}/icons/${item.image}`;
   img.alt = item.name;
   imageContainer.appendChild(img);

--- a/simulator_bloodborne.html
+++ b/simulator_bloodborne.html
@@ -3,10 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Bloodborne Outfit Simulator</title>
-	<title>Bloodborne outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Bloodborne outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="bloodborne" id="backToMain" class="back-link">← Back to Bloodborne Outfit Selection</a>

--- a/simulator_demonssouls.html
+++ b/simulator_demonssouls.html
@@ -3,10 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Demon's Souls Outfit Simulator</title>
-	<title>Demon's Souls outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Demon's Souls outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="demonssouls" id="backToMain" class="back-link">← Back to Demon's Souls Outfit Selection</a>

--- a/simulator_ds1.html
+++ b/simulator_ds1.html
@@ -3,10 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Dark Souls Outfit Simulator</title>
-	<title>Dark Souls outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Dark Souls outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="ds1" id="backToMain" class="back-link">← Back to Dark Souls Outfit Selection</a>

--- a/simulator_ds2.html
+++ b/simulator_ds2.html
@@ -3,10 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
-    <title>Dark Souls 2 Outfit Simulator</title>
-	<title>Dark Souls 2 outfit simulator - Fashion Souls v1.0.8</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
+    <title>Dark Souls 2 outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="ds2" id="backToMain" class="back-link">← Back to Dark Souls 2 Outfit Selection</a>
@@ -66,62 +67,6 @@
 
 <script>
 	const gamePrefix = "ds2_"; // Unique prefix for LocalStorage handling
-    // Function to edit a preset name
-    function editPresetName(presetNumber) {
-        const presetNameElement = document.getElementById(`presetName${presetNumber}`);
-        
-        // Save the original name in case the user doesn't enter a new one
-        const originalName = presetNameElement.textContent.trim();
-
-        // Clear the text when clicked to edit
-        presetNameElement.textContent = "";
-
-        // Save the updated name when focus is lost
-        presetNameElement.addEventListener("blur", () => {
-            const name = presetNameElement.textContent.trim();
-
-            if (name === "") {
-                // If no new name is provided, revert to the original name
-                presetNameElement.textContent = originalName;
-            } else {
-                // Otherwise, save the new name
-                localStorage.setItem(gamePrefix + `presetName${presetNumber}`, name);
-            }
-        }, { once: true });
-
-        // Save the updated name when the Enter key is pressed
-        presetNameElement.addEventListener("keydown", (event) => {
-            if (event.key === "Enter") {
-                event.preventDefault(); // Prevent newline
-                presetNameElement.blur(); // Trigger blur event to save
-            }
-        });
-    }
-
-    // Function to load preset names from localStorage
-    function loadPresetNames() {
-        for (let i = 1; i <= 5; i++) {
-            const name = localStorage.getItem(gamePrefix + `presetName${i}`) || `Preset ${i}`;
-            document.getElementById(`presetName${i}`).textContent = name;
-        }
-    }
-
-    // Function to clear a preset
-    function clearPreset(presetNumber) {
-        localStorage.removeItem(gamePrefix + `preset${presetNumber}`);
-    }
-
- 
-    // Load preset names and outfit on page load
-    document.addEventListener("DOMContentLoaded", () => {
-        loadPresetNames();
-        loadOutfitFromStorage();
-    });
-</script>
-
-
-
-<script>
     // Function to edit a preset name
     function editPresetName(presetNumber) {
         const presetNameElement = document.getElementById(`presetName${presetNumber}`);
@@ -329,25 +274,6 @@
         loadOutfitFromStorage();
     });
 	
-	//dismiss full-screen notice
-	document.addEventListener("DOMContentLoaded", () => {
-    const fullScreenNotice = document.getElementById('fullScreenNotice');
-    const dismissNotice = document.getElementById('dismissNotice');
-
-    // Check if the notice has already been dismissed
-    if (!localStorage.getItem('noticeDismissed')) {
-        fullScreenNotice.style.display = 'flex'; // Show the notice overlay
-    } else {
-        fullScreenNotice.style.display = 'none'; // Hide it if already dismissed
-    }
-
-    // Add click event to dismiss the notice
-    dismissNotice.addEventListener('click', (event) => {
-        event.preventDefault();
-        fullScreenNotice.style.display = 'none'; // Hide the notice
-        localStorage.setItem('noticeDismissed', 'true'); // Save dismissal to localStorage
-    });
-});
 
 </script>
 

--- a/simulator_ds3.html
+++ b/simulator_ds3.html
@@ -3,10 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Dark Souls 3 Outfit Simulator</title>
-	<title>Dark Souls 3 outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Dark Souls 3 outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="ds3" id="backToMain" class="back-link">← Back to Dark Souls 3 Outfit Selection</a>

--- a/simulator_eldenring.html
+++ b/simulator_eldenring.html
@@ -3,10 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Spectral">
-	<link rel="stylesheet" href="resources/styles.css?v1.0.7">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;600;700&display=swap">
+	<link rel="stylesheet" href="resources/styles.css?v1.0.9">
     <title>Elden Ring Outfit Simulator</title>
-	<title>Elden Ring outfit simulator - Fashion Souls v1.0.8</title>
+	<title>Elden Ring outfit simulator - Fashion Souls v1.0.9</title>
 </head>
 <body>
     <a href="eldenring" id="backToMain" class="back-link">← Back to Elden Ring Outfit Selection</a>


### PR DESCRIPTION
### Motivation
- Improve mobile and desktop UX by adding a tile zoom control and pinch-to-zoom for the item grid.  
- Make drag-and-drop interactions more robust and visually clearer when moving items into outfit slots.  
- Modernize asset loading (Google Fonts), bump resource versions, and make the preloader hide reliably after initial grid images render.  

### Description
- Added a grid zoom UI and persistent tile scaling via a new `gridZoomSlider` and `gridZoomValue`, with `applyGridScale` and `initGridZoomControl` logic stored in page scripts and a `--item-card-scale` CSS variable.  
- Implemented pinch-to-zoom on touch devices (`setupPinchZoom`) and improved scroll handling with `requestAnimationFrame` (`onScroll` / `updateScrollUI`) and responsive mobile sidebar behavior via `body` classes `mobile-sidebar-visible` and `mobile-controls-visible`.  
- Enhanced drag-and-drop: item cards now set `dataTransfer.effectAllowed = 'move'`, add `dragging` class, emit `is-dragging-item` body class, slot `drop-target` highlighting, and drop handling now uses the already-loaded `items` array instead of refetching JSON.  
- Improved preloader lifecycle to listen for custom `initial-grid-images-loaded` event (emitted from `search_items.js`) and to hide with a CSS transition, with a fallback timeout.  
- Prevented unwanted image dragging via `img.draggable = false` and CSS (`img { -webkit-user-drag: none; }`), added `loading=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1503900208325b04402d0621717dc)